### PR TITLE
Add scenario for .none extra

### DIFF
--- a/scenarios/extras.json
+++ b/scenarios/extras.json
@@ -288,5 +288,41 @@
                 "a": "3.0.0"
             }
         }
+    },
+    {
+        "name": "none-extra",
+        "description": "Package has an invalid extra named .none.",
+        "root": {
+            "requires": [
+                "a[.none,extra_b]"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "extras": {
+                            ".none": [],
+                            "extra_b": [
+                                "b"
+                            ]
+                        }
+                    }
+                }
+            },
+            "b": {
+                "versions": {
+                    "1.0.0": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "explanation": "Invalid extras are ignored during resolution.",
+            "packages": {
+                "a": "1.0.0",
+                "b": "1.0.0"
+            }
+        }
     }
 ]

--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -6,14 +6,12 @@ import shutil
 import subprocess
 import textwrap
 import time
-import re
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_futures
 from pathlib import Path
 from typing import Generator
 
 import packaging.version
-
 from packaging.requirements import Requirement
 
 from packse.error import (

--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -204,12 +204,14 @@ def make_root_package(scenario: Scenario) -> Package:
         }
     )
 
+
 def remove_invalid_extras(dependency: Requirement) -> Requirement:
-    valid_extras = [extra for extra in dependency.extras if not extra.startswith('.')]
+    valid_extras = [extra for extra in dependency.extras if not extra.startswith(".")]
     if valid_extras:
         return Requirement(f"{dependency.name}[{','.join(valid_extras)}]")
     else:
         return Requirement(dependency.name)
+
 
 def build_scenario_package(
     scenario: Scenario,
@@ -265,6 +267,7 @@ def build_scenario_package(
                         ],
                     }
                     for extra, depends in package_version.extras.items()
+                    if not extra.startswith(".")
                 ],
                 "requires-python": package_version.requires_python,
                 "description": package_version.description,

--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -206,11 +206,21 @@ def make_root_package(scenario: Scenario) -> Package:
 
 
 def remove_invalid_extras(dependency: Requirement) -> Requirement:
+    if not dependency.extras:
+        return dependency
+
     valid_extras = [extra for extra in dependency.extras if not extra.startswith(".")]
     if valid_extras:
-        return Requirement(f"{dependency.name}[{','.join(valid_extras)}]")
+        extras_str = ",".join(valid_extras)
+        url = dependency.url if dependency.url else ""
+        marker = f";{dependency.marker}" if dependency.marker else ""
+        return Requirement(
+            f"{dependency.name}{dependency.specifier}[{extras_str}]{url}{marker}"
+        )
     else:
-        return Requirement(dependency.name)
+        url = dependency.url if dependency.url else ""
+        marker = f";{dependency.marker}" if dependency.marker else ""
+        return Requirement(f"{dependency.name}{dependency.specifier}{url}{marker}")
 
 
 def build_scenario_package(

--- a/src/packse/scenario.py
+++ b/src/packse/scenario.py
@@ -16,6 +16,7 @@ type PackageVersion = (
     str  # TODO(zanieb): Consider replacing with `packaging.version.Version`
 )
 
+
 def _parse_extras(requirement_string: str) -> tuple[str, set[str]]:
     """
     Parse extras from a requirement string, handling .none extras separately.
@@ -30,11 +31,17 @@ def _parse_extras(requirement_string: str) -> tuple[str, set[str]]:
         i = requirement_string.find("[")
         j = requirement_string.find("]", i)
         if j != -1:
-            extras_str = requirement_string[i+1:j]
+            extras_str = requirement_string[i + 1 : j]
             extras = set(e.strip() for e in extras_str.split(","))
             none_extras = set(e for e in extras if e.startswith("."))
             extras -= none_extras
-            requirement_string = requirement_string[:i] + "[" + ",".join(extras) + "]" + requirement_string[j+1:]
+            requirement_string = (
+                requirement_string[:i]
+                + "["
+                + ",".join(extras)
+                + "]"
+                + requirement_string[j + 1 :]
+            )
         else:
             none_extras = set()
             extras = set()
@@ -43,6 +50,7 @@ def _parse_extras(requirement_string: str) -> tuple[str, set[str]]:
         extras = set()
 
     return requirement_string, extras, none_extras
+
 
 class Requirement(packaging.requirements.Requirement):
     """
@@ -55,7 +63,7 @@ class Requirement(packaging.requirements.Requirement):
         library to provide custom handling of .none extras.
         https://github.com/pypa/packaging/blob/main/src/packaging/requirements.py
         """
-                
+
         requirement_string, extras, none_extras = _parse_extras(requirement_string)
 
         try:
@@ -66,12 +74,16 @@ class Requirement(packaging.requirements.Requirement):
         self.name: str = req.name
         self.url: str | None = req.url or None
         self.extras: set[str] = set(req.extras) | extras | none_extras
-        self.specifier: packaging.specifiers.SpecifierSet = packaging.specifiers.SpecifierSet(str(req.specifier))
+        self.specifier: packaging.specifiers.SpecifierSet = (
+            packaging.specifiers.SpecifierSet(str(req.specifier))
+        )
         self.marker: Marker | None = None
 
         if req.marker is not None:
             self.marker = Marker.__new__(Marker)
-            self.marker._markers = packaging.requirements._normalize_extra_values(req.marker)
+            self.marker._markers = packaging.requirements._normalize_extra_values(
+                req.marker
+            )
 
     def __lt__(self, other: Any) -> True:
         """


### PR DESCRIPTION
Added a .none scenario in `extras.json`, but running `poetry run packse view scenarios/extras.json` threw this `PEP508` related error:

```bash
File at 'scenarios/extras.json' is not a valid scenario: Expected matching RIGHT_BRACKET for LEFT_BRACKET, after extras
    a[.none,extra_b]
     ~^ - at `$[8].root.requires[0]`.
```

Resolved this by making a small change to the `__init__` method of the Requirement class to handle .none extras separately.

Closes [https://github.com/astral-sh/uv/issues/1430](https://github.com/astral-sh/uv/issues/1430)