### PR TITLE
Add Exclusive prerelease specifier scenarios

### DIFF
--- a/scenarios/prereleases.json
+++ b/scenarios/prereleases.json
@@ -170,6 +170,58 @@
         }
     },
     {
+        "name": "package-exclusive-ordered-comparison-prerelease-specified-mixed-available",
+        "description": "The user requires a version of `a` with an exclusive ordered comparison prerelease specifier and both prerelease and stable releases are available.",
+        "root": {
+            "requires": [
+                "a>0.1.0a1"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "0.1.0": {},
+                    "0.2.0a1": {},
+                    "0.3.0": {},
+                    "1.0.0a1": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.0.0a1"
+            },
+            "explanation": "Since the user provided a prerelease specifier, the latest prerelease version should be selected, even though an exclusive ordered comparison was used."
+        }
+    },
+    {
+        "name": "package-not-equal-prerelease-specified-mixed-available",
+        "description": "The user requires a version of `a` which is not a specific prerelease version, and both prerelease and stable releases are available.",
+        "root": {
+            "requires": [
+                "a!=0.2.0a1"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "0.1.0": {},
+                    "0.2.0a1": {},
+                    "0.3.0": {},
+                    "1.0.0a1": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "0.3.0"
+            },
+            "explanation": "Even though a prerelease specifier was given, it was '!=', which does not imply prereleases should be selected, therefore the latest final release should be chosen."
+        }
+    },
+    {
         "name": "package-multiple-prereleases-kinds",
         "description": "The user requires `a` which has multiple prereleases available with different labels.",
         "root": {


### PR DESCRIPTION
My first attempt at a PR, let's see how it goes.

This adds two extra scenarios to prerelease specifiers, uv already correctly follows the `>` exclusive ordered test: https://github.com/astral-sh/uv/issues/2646, but packaging (and therefore pip) does not: https://github.com/pypa/packaging/issues/788

I do not know whether uv implies prerelease from `!=` or not, and I'm not explicitly getting it from the the spec but rather following this comment by the spec author https://github.com/pypa/packaging/issues/776#issuecomment-1900515985, we can wait and see if the explicit test on that check is accepted by packaging in my PR https://github.com/pypa/packaging/pull/794.
