### PR TITLE
add initial support for universal resolver tests

### DIFF
--- a/scenarios/fork/basic.toml
+++ b/scenarios/fork/basic.toml
@@ -1,0 +1,20 @@
+name = "fork-basic"
+description = '''
+An extremely basic test of universal resolution. In this case, the resolution
+should contain two distinct versions of `a` depending on `sys_platform`.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a>=2 ; sys_platform == 'linux'",
+  "a<2 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."1.0.0"]
+[packages.a.versions."2.0.0"]

--- a/scenarios/fork/marker-accrue.toml
+++ b/scenarios/fork/marker-accrue.toml
@@ -1,0 +1,28 @@
+name = "fork-marker-accrue"
+description = '''
+This is actually a non-forking test case that tests the tracking of marker
+expressions in general. In this case, the dependency on `c` should have its
+marker expressions automatically combined. In this case, it's `linux OR
+darwin`, even though `linux OR darwin` doesn't actually appear verbatim as a
+marker expression for any dependency on `c`.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a==1.0.0 ; implementation_name == 'cpython'",
+  "b==1.0.0 ; implementation_name == 'pypy'",
+]
+
+[packages.a.versions."1.0.0"]
+requires = ["c==1.0.0 ; sys_platform == 'linux'"]
+
+[packages.b.versions."1.0.0"]
+requires = ["c==1.0.0 ; sys_platform == 'darwin'"]
+
+[packages.c.versions."1.0.0"]

--- a/scenarios/fork/marker-selection.toml
+++ b/scenarios/fork/marker-selection.toml
@@ -1,0 +1,28 @@
+name = "fork-marker-selection"
+description = '''
+This tests a case where the resolver forks because of non-overlapping marker
+expressions on `b`. In the original universal resolver implementation, this
+resulted in multiple versions of `a` being unconditionally included in the lock
+file. So this acts as a regression test to ensure that only one version of `a`
+is selected.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a",
+  "b>=2 ; sys_platform == 'linux'",
+  "b<2 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."0.1.0"]
+[packages.a.versions."0.2.0"]
+requires = ["b>=2.0.0"]
+
+[packages.b.versions."1.0.0"]
+[packages.b.versions."2.0.0"]

--- a/scenarios/fork/marker-track.toml
+++ b/scenarios/fork/marker-track.toml
@@ -1,0 +1,30 @@
+name = "fork-marker-track"
+description = '''
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a",
+  "b>=2.8 ; sys_platform == 'linux'",
+  "b<2.8 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."1.3.1"]
+requires = ["c ; implementation_name == 'iron'"]
+[packages.a.versions."2.0.0"]
+requires = ["b>=2.8", "c ; implementation_name == 'cpython'"]
+[packages.a.versions."3.1.0"]
+requires = ["b>=2.8", "c ; implementation_name == 'pypy'"]
+[packages.a.versions."4.3.0"]
+requires = ["b>=2.8"]
+
+[packages.b.versions."2.7"]
+[packages.b.versions."2.8"]
+
+[packages.c.versions."1.10"]

--- a/scenarios/fork/non-fork-marker-transitive.toml
+++ b/scenarios/fork/non-fork-marker-transitive.toml
@@ -1,0 +1,24 @@
+name = "fork-non-fork-marker-transitive"
+description = '''
+This is the same setup as `non-local-fork-marker-transitive`, but the disjoint
+dependency specifications on `c` use the same constraints and thus depend on
+the same version of `c`. In this case, there is no conflict.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["a==1.0.0", "b==1.0.0"]
+
+[packages.a.versions."1.0.0"]
+requires = ["c>=2.0.0 ; sys_platform == 'linux'"]
+
+[packages.b.versions."1.0.0"]
+requires = ["c>=2.0.0 ; sys_platform == 'darwin'"]
+
+[packages.c.versions."1.0.0"]
+[packages.c.versions."2.0.0"]

--- a/scenarios/fork/non-local-fork-marker-direct.toml
+++ b/scenarios/fork/non-local-fork-marker-direct.toml
@@ -1,0 +1,28 @@
+name = "fork-non-local-fork-marker-direct"
+description = '''
+This is like `non-local-fork-marker-transitive`, but the marker expressions are
+placed on sibling dependency specifications. However, the actual dependency on
+`c` is indirect, and thus, there's no fork detected by the universal resolver.
+This in turn results in an unresolvable conflict on `c`.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires = [
+  "a==1.0.0 ; sys_platform == 'linux'",
+  "b==1.0.0 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."1.0.0"]
+requires = ["c<2.0.0"]
+
+[packages.b.versions."1.0.0"]
+requires = ["c>=2.0.0"]
+
+[packages.c.versions."1.0.0"]
+[packages.c.versions."2.0.0"]

--- a/scenarios/fork/non-local-fork-marker-transitive.toml
+++ b/scenarios/fork/non-local-fork-marker-transitive.toml
@@ -1,0 +1,31 @@
+name = "fork-non-local-fork-marker-transitive"
+description = '''
+This setup introduces dependencies on two distinct versions of `c`, where
+each such dependency has a marker expression attached that would normally
+make them disjoint. In a non-universal resolver, this is no problem. But in a
+forking resolver that tries to create one universal resolution, this can lead
+to two distinct versions of `c` in the resolution. This is in and of itself
+not a problem, since that is an expected scenario for universal resolution.
+The problem in this case is that because the dependency specifications for
+`c` occur in two different points (i.e., they are not sibling dependency
+specifications) in the dependency graph, the forking resolver does not "detect"
+it, and thus never forks and thus this results in "no resolution."
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires = ["a==1.0.0", "b==1.0.0"]
+
+[packages.a.versions."1.0.0"]
+requires = ["c<2.0.0 ; sys_platform == 'linux'"]
+
+[packages.b.versions."1.0.0"]
+requires = ["c>=2.0.0 ; sys_platform == 'darwin'"]
+
+[packages.c.versions."1.0.0"]
+[packages.c.versions."2.0.0"]

--- a/src/packse/scenario.py
+++ b/src/packse/scenario.py
@@ -130,6 +130,15 @@ class ResolverOptions(msgspec.Struct, forbid_unknown_fields=True):
     A source distribution is required to build the packages.
     """
 
+    universal: bool = False
+    """
+    If resolution should operate in "universal" mode.
+
+    In universal mode, a resolution can contain multiple versions of
+    the same packages, but where different versions must be guarded by
+    non-overlapping marker expressions.
+    """
+
     def hash(self) -> str:
         """
         Return a hash of the contents

--- a/src/packse/templates/package/{{ package-name }}-{{ version }}/pyproject.toml
+++ b/src/packse/templates/package/{{ package-name }}-{{ version }}/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [{{# dependencies }}
     '''{{ . }}''',
 {{/ dependencies }}]
 requires-python = "{{ requires-python }}"
-description = "{{ description }}"
+description = '''{{ description }}'''
 
 [project.optional-dependencies]
 {{# optional-dependencies }}

--- a/tests/__snapshots__/test_build.ambr
+++ b/tests/__snapshots__/test_build.ambr
@@ -26,7 +26,7 @@
             '''example-a-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`."
+        description = '''This is an example scenario, in which the user depends on a single package `a` which requires `b`.'''
         
         [project.optional-dependencies]
   
@@ -58,7 +58,7 @@
             '''example-b-961b4c22>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -88,7 +88,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -118,7 +118,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -150,7 +150,7 @@
             '''example-c-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -159,15 +159,15 @@
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:50500dbebf471373976c812752281082',
+      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:c623a99299b9af5baa182903e5cc23a8',
       'dist/example-961b4c22/example_a_961b4c22-1.0.0-py3-none-any.whl': 'md5:b08225196dab082ef56cfd200be09e0c',
-      'dist/example-961b4c22/example_a_961b4c22-1.0.0.tar.gz': 'md5:d5b206e5473bbc4625cfd2a0635c14ee',
+      'dist/example-961b4c22/example_a_961b4c22-1.0.0.tar.gz': 'md5:ab066ac0b68cfff19bcc2e8956c365ed',
       'dist/example-961b4c22/example_b_961b4c22-1.0.0-py3-none-any.whl': 'md5:d5671062b6263efec113c4a48722e3f8',
-      'dist/example-961b4c22/example_b_961b4c22-1.0.0.tar.gz': 'md5:1a5b78e5effdddfb166da60f3765542e',
+      'dist/example-961b4c22/example_b_961b4c22-1.0.0.tar.gz': 'md5:3f028fa3710a02f7c913b2f9d87c0ece',
       'dist/example-961b4c22/example_b_961b4c22-2.0.0-py3-none-any.whl': 'md5:1af716031481e9892c3043c65b315688',
-      'dist/example-961b4c22/example_b_961b4c22-2.0.0.tar.gz': 'md5:d6ef5021da7cd4275188bd8d086d5229',
+      'dist/example-961b4c22/example_b_961b4c22-2.0.0.tar.gz': 'md5:96c95899375aad77792ffe596c18727b',
       'dist/example-961b4c22/example_b_961b4c22-3.0.0-py3-none-any.whl': 'md5:9d6c858ff25fa695b68a09914fd5f0de',
-      'dist/example-961b4c22/example_b_961b4c22-3.0.0.tar.gz': 'md5:f97684a46574b1d9d4209fb639a5c660',
+      'dist/example-961b4c22/example_b_961b4c22-3.0.0.tar.gz': 'md5:4f2848a296b07dde840aaa9f317fdf6e',
       'tree': '''
         test_build_example0
         ├── build
@@ -280,7 +280,7 @@
             '''b-961b4c22>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -310,7 +310,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -340,7 +340,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -372,7 +372,7 @@
             '''c-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -404,7 +404,7 @@
             '''a-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`."
+        description = '''This is an example scenario, in which the user depends on a single package `a` which requires `b`.'''
         
         [project.optional-dependencies]
   
@@ -414,14 +414,14 @@
   
       ''',
       'dist/example-961b4c22/a_961b4c22-1.0.0-py3-none-any.whl': 'md5:71835d4655093021b26881ed536d6a3c',
-      'dist/example-961b4c22/a_961b4c22-1.0.0.tar.gz': 'md5:5e4419947505c407666321769ae37b6f',
+      'dist/example-961b4c22/a_961b4c22-1.0.0.tar.gz': 'md5:57a584f374e28ec30a4b9e362f952da1',
       'dist/example-961b4c22/b_961b4c22-1.0.0-py3-none-any.whl': 'md5:87a6833860657a740cfc3dd6c33ed6c0',
-      'dist/example-961b4c22/b_961b4c22-1.0.0.tar.gz': 'md5:9ba9d4c05c2cfc71d316a724bcee9941',
+      'dist/example-961b4c22/b_961b4c22-1.0.0.tar.gz': 'md5:59f339707c0b6b5c2e808aa6093f2201',
       'dist/example-961b4c22/b_961b4c22-2.0.0-py3-none-any.whl': 'md5:827509625d3d713b04592c1e81650507',
-      'dist/example-961b4c22/b_961b4c22-2.0.0.tar.gz': 'md5:3f0d5cc2ca6029de28220d81a67fdcd6',
+      'dist/example-961b4c22/b_961b4c22-2.0.0.tar.gz': 'md5:dd8d2ac815fdcf988510111146938f9f',
       'dist/example-961b4c22/b_961b4c22-3.0.0-py3-none-any.whl': 'md5:03b775c2e2c672d972ab6c9780508b31',
-      'dist/example-961b4c22/b_961b4c22-3.0.0.tar.gz': 'md5:9319bd71ba7767b4c445e5642af84f41',
-      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:7c52a2c4677494a1f90f5017f85273e4',
+      'dist/example-961b4c22/b_961b4c22-3.0.0.tar.gz': 'md5:4c85a2580ccfa5815711d2039fa77154',
+      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:3125dd39aeeba6cdf63463ec944242f4',
       'tree': '''
         test_build_example_short_names0
         ├── build
@@ -506,7 +506,7 @@
             '''example-a-7661fdb8''',
         ]
         requires-python = ">=3.8"
-        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`."
+        description = '''This is an example scenario, in which the user depends on a single package `a` which requires `b`.'''
         
         [project.optional-dependencies]
   
@@ -538,7 +538,7 @@
             '''example-b-7661fdb8>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -568,7 +568,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -598,7 +598,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -630,7 +630,7 @@
             '''example-c-7661fdb8''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -639,15 +639,15 @@
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-7661fdb8/example_7661fdb8-0.0.0.tar.gz': 'md5:a7d08c4c6d67ea155e60aa4dca1d4f02',
+      'dist/example-7661fdb8/example_7661fdb8-0.0.0.tar.gz': 'md5:4b8b390e5fa91da7b8671f7e93447822',
       'dist/example-7661fdb8/example_a_7661fdb8-1.0.0-py3-none-any.whl': 'md5:2bffa37b533d8bd7305ef4c35f2e1eaa',
-      'dist/example-7661fdb8/example_a_7661fdb8-1.0.0.tar.gz': 'md5:72ff3160331e769af9ca18f8e5556521',
+      'dist/example-7661fdb8/example_a_7661fdb8-1.0.0.tar.gz': 'md5:80562a27c81b04c73469ff4f82a9f432',
       'dist/example-7661fdb8/example_b_7661fdb8-1.0.0-py3-none-any.whl': 'md5:e28d01bec9f17c084c41faae02beb5b2',
-      'dist/example-7661fdb8/example_b_7661fdb8-1.0.0.tar.gz': 'md5:30555584f112a9476b36fa69b588a32b',
+      'dist/example-7661fdb8/example_b_7661fdb8-1.0.0.tar.gz': 'md5:8fe04976492123c9106367b8063f971c',
       'dist/example-7661fdb8/example_b_7661fdb8-2.0.0-py3-none-any.whl': 'md5:0382ed0f92262b84e41d8a172d117484',
-      'dist/example-7661fdb8/example_b_7661fdb8-2.0.0.tar.gz': 'md5:b87e755e31b565d48830d77ae95ae803',
+      'dist/example-7661fdb8/example_b_7661fdb8-2.0.0.tar.gz': 'md5:18ed4f0c64291d61616b3a764df46617',
       'dist/example-7661fdb8/example_b_7661fdb8-3.0.0-py3-none-any.whl': 'md5:00ec1e77f1d74ba49814a30ac3b92e99',
-      'dist/example-7661fdb8/example_b_7661fdb8-3.0.0.tar.gz': 'md5:14aa3376162ccb7d9c6bb5156cd8fe10',
+      'dist/example-7661fdb8/example_b_7661fdb8-3.0.0.tar.gz': 'md5:349072166c002797ac0ab76178695155',
       'tree': '''
         test_build_example_with_seed0
         ├── build

--- a/tests/__snapshots__/test_build_pkg.ambr
+++ b/tests/__snapshots__/test_build_pkg.ambr
@@ -24,7 +24,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -34,7 +34,7 @@
   
       ''',
       'dist/foo/foo-1.0.0-py3-none-any.whl': 'md5:80be08b501ed397bb67c604755b17414',
-      'dist/foo/foo-1.0.0.tar.gz': 'md5:2d7ae4b5428eac91e982582578e28f01',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:43b0be7653be5e7e0c159c5296602032',
       'tree': '''
         test_build_pkg0
         ├── build
@@ -114,7 +114,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -191,7 +191,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -200,7 +200,7 @@
         __version__ = "1.0.0"
   
       ''',
-      'dist/foo/foo-1.0.0.tar.gz': 'md5:2d7ae4b5428eac91e982582578e28f01',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:43b0be7653be5e7e0c159c5296602032',
       'tree': '''
         test_build_pkg_no_wheel0
         ├── build
@@ -254,7 +254,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -265,7 +265,7 @@
       ''',
       'dist/foo/foo-1.0.0-tag1.whl': 'md5:80be08b501ed397bb67c604755b17414',
       'dist/foo/foo-1.0.0-tag2.whl': 'md5:80be08b501ed397bb67c604755b17414',
-      'dist/foo/foo-1.0.0.tar.gz': 'md5:2d7ae4b5428eac91e982582578e28f01',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:43b0be7653be5e7e0c159c5296602032',
       'tree': '''
         test_build_pkg_wheel_tags0
         ├── build

--- a/tests/__snapshots__/test_inspect.ambr
+++ b/tests/__snapshots__/test_inspect.ambr
@@ -113,7 +113,8 @@
               "python": null,
               "prereleases": false,
               "no_build": [],
-              "no_binary": []
+              "no_binary": [],
+              "universal": false
             },
             "template": "package",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`.",
@@ -248,7 +249,8 @@
               "python": null,
               "prereleases": false,
               "no_build": [],
-              "no_binary": []
+              "no_binary": [],
+              "universal": false
             },
             "template": "package",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`.",
@@ -410,7 +412,8 @@
               "python": null,
               "prereleases": false,
               "no_build": [],
-              "no_binary": []
+              "no_binary": [],
+              "universal": false
             },
             "template": "package",
             "description": "This is an example scenario written in TOML, in which the user depends on a single package `a` which requires `b`.",
@@ -545,7 +548,8 @@
               "python": null,
               "prereleases": false,
               "no_build": [],
-              "no_binary": []
+              "no_binary": [],
+              "universal": false
             },
             "template": "package",
             "description": "This is an example scenario written in YAML, in which the user depends on a single package `a` which requires `b`.",

--- a/tests/__snapshots__/test_scenarios.ambr
+++ b/tests/__snapshots__/test_scenarios.ambr
@@ -26,7 +26,7 @@
             '''example-a-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`."
+        description = '''This is an example scenario, in which the user depends on a single package `a` which requires `b`.'''
         
         [project.optional-dependencies]
   
@@ -58,7 +58,7 @@
             '''example-b-961b4c22>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -88,7 +88,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -118,7 +118,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -150,7 +150,7 @@
             '''example-c-961b4c22''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -159,15 +159,15 @@
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:50500dbebf471373976c812752281082',
+      'dist/example-961b4c22/example_961b4c22-0.0.0.tar.gz': 'md5:c623a99299b9af5baa182903e5cc23a8',
       'dist/example-961b4c22/example_a_961b4c22-1.0.0-py3-none-any.whl': 'md5:b08225196dab082ef56cfd200be09e0c',
-      'dist/example-961b4c22/example_a_961b4c22-1.0.0.tar.gz': 'md5:d5b206e5473bbc4625cfd2a0635c14ee',
+      'dist/example-961b4c22/example_a_961b4c22-1.0.0.tar.gz': 'md5:ab066ac0b68cfff19bcc2e8956c365ed',
       'dist/example-961b4c22/example_b_961b4c22-1.0.0-py3-none-any.whl': 'md5:d5671062b6263efec113c4a48722e3f8',
-      'dist/example-961b4c22/example_b_961b4c22-1.0.0.tar.gz': 'md5:1a5b78e5effdddfb166da60f3765542e',
+      'dist/example-961b4c22/example_b_961b4c22-1.0.0.tar.gz': 'md5:3f028fa3710a02f7c913b2f9d87c0ece',
       'dist/example-961b4c22/example_b_961b4c22-2.0.0-py3-none-any.whl': 'md5:1af716031481e9892c3043c65b315688',
-      'dist/example-961b4c22/example_b_961b4c22-2.0.0.tar.gz': 'md5:d6ef5021da7cd4275188bd8d086d5229',
+      'dist/example-961b4c22/example_b_961b4c22-2.0.0.tar.gz': 'md5:96c95899375aad77792ffe596c18727b',
       'dist/example-961b4c22/example_b_961b4c22-3.0.0-py3-none-any.whl': 'md5:9d6c858ff25fa695b68a09914fd5f0de',
-      'dist/example-961b4c22/example_b_961b4c22-3.0.0.tar.gz': 'md5:f97684a46574b1d9d4209fb639a5c660',
+      'dist/example-961b4c22/example_b_961b4c22-3.0.0.tar.gz': 'md5:4f2848a296b07dde840aaa9f317fdf6e',
       'tree': '''
         test_build_test_scenarios_exam0
         ├── build
@@ -234,7 +234,7 @@
         *.pyc
   
       ''',
-      'build/example-toml-4a4ede4d/example-toml-4a4ede4d-0.0.0/pyproject.toml': 'md5:09873097a1bbbb1e6090f438bd379150',
+      'build/example-toml-4a4ede4d/example-toml-4a4ede4d-0.0.0/pyproject.toml': 'md5:a531b7b0544fb70b1c705bbda8a6724c',
       'build/example-toml-4a4ede4d/example-toml-4a4ede4d-0.0.0/src/example_toml_4a4ede4d/__init__.py': '''
         __version__ = "0.0.0"
   
@@ -262,7 +262,7 @@
             '''example-toml-b-4a4ede4d>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -292,7 +292,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -322,7 +322,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -354,7 +354,7 @@
             '''example-toml-c-4a4ede4d''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -363,15 +363,15 @@
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-toml-4a4ede4d/example_toml_4a4ede4d-0.0.0.tar.gz': 'md5:1f276537bcbf0be4b70ce8b713bf18a0',
+      'dist/example-toml-4a4ede4d/example_toml_4a4ede4d-0.0.0.tar.gz': 'md5:b1bca6825276fa8bf4d5b9e48586b338',
       'dist/example-toml-4a4ede4d/example_toml_a_4a4ede4d-1.0.0-py3-none-any.whl': 'md5:f79d086336d205c960e26ea13bbe2d01',
-      'dist/example-toml-4a4ede4d/example_toml_a_4a4ede4d-1.0.0.tar.gz': 'md5:764b05f0e614c4a70576ca1d1ea3892c',
+      'dist/example-toml-4a4ede4d/example_toml_a_4a4ede4d-1.0.0.tar.gz': 'md5:120b7924b813c094e0ae1661cf4d90c1',
       'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-1.0.0-py3-none-any.whl': 'md5:1c56e586db3b49bc418a73a6e71aa725',
-      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-1.0.0.tar.gz': 'md5:a917472b63fe11f466c0adfbe68f082c',
+      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-1.0.0.tar.gz': 'md5:e5cde4a65a4ceed7f25772c1d170f53b',
       'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-2.0.0-py3-none-any.whl': 'md5:046f5ff1261d5507c030ca555eda4119',
-      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-2.0.0.tar.gz': 'md5:544b4f86e34cbc2bf2b09bac44554db5',
+      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-2.0.0.tar.gz': 'md5:df6a3922cf54ee7e746dddd59b8b98a9',
       'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-3.0.0-py3-none-any.whl': 'md5:ab3216e8426d1a9992e88e9f1a8e6614',
-      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-3.0.0.tar.gz': 'md5:43048cc9f4f37ea21564ed90684d3ff3',
+      'dist/example-toml-4a4ede4d/example_toml_b_4a4ede4d-3.0.0.tar.gz': 'md5:e1f9cbf7e0fe50cba02f1a7a5838c5a3',
       'tree': '''
         test_build_test_scenarios_exam1
         ├── build
@@ -438,7 +438,7 @@
         *.pyc
   
       ''',
-      'build/example-yaml-4692130b/example-yaml-4692130b-0.0.0/pyproject.toml': 'md5:e1c599a778fbaf29f0217f69bae5f263',
+      'build/example-yaml-4692130b/example-yaml-4692130b-0.0.0/pyproject.toml': 'md5:47ff40e1cb004e6b8e2a196c83b3d5d5',
       'build/example-yaml-4692130b/example-yaml-4692130b-0.0.0/src/example_yaml_4692130b/__init__.py': '''
         __version__ = "0.0.0"
   
@@ -466,7 +466,7 @@
             '''example-yaml-b-4692130b>1.0.0''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -496,7 +496,7 @@
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -526,7 +526,7 @@
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -558,7 +558,7 @@
             '''example-yaml-c-4692130b''',
         ]
         requires-python = ">=3.8"
-        description = ""
+        description = ''''''
         
         [project.optional-dependencies]
   
@@ -567,15 +567,15 @@
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-yaml-4692130b/example_yaml_4692130b-0.0.0.tar.gz': 'md5:1f27fb4954cf95d3df2816e0a3df68c3',
+      'dist/example-yaml-4692130b/example_yaml_4692130b-0.0.0.tar.gz': 'md5:99ffbae55dd5142f1dc948380b457b4f',
       'dist/example-yaml-4692130b/example_yaml_a_4692130b-1.0.0-py3-none-any.whl': 'md5:28315840a7506c6077ab74c589437c07',
-      'dist/example-yaml-4692130b/example_yaml_a_4692130b-1.0.0.tar.gz': 'md5:26e8387f05600e41417bb463cbf0b168',
+      'dist/example-yaml-4692130b/example_yaml_a_4692130b-1.0.0.tar.gz': 'md5:78dbe472c29db060370a4d50c5335480',
       'dist/example-yaml-4692130b/example_yaml_b_4692130b-1.0.0-py3-none-any.whl': 'md5:d67abed60ef9014f50aea61f14f9a820',
-      'dist/example-yaml-4692130b/example_yaml_b_4692130b-1.0.0.tar.gz': 'md5:01c9e292760272b477f4a02ba22e1fff',
+      'dist/example-yaml-4692130b/example_yaml_b_4692130b-1.0.0.tar.gz': 'md5:82f96b858ab3d4d62ce86c1a2ab289d7',
       'dist/example-yaml-4692130b/example_yaml_b_4692130b-2.0.0-py3-none-any.whl': 'md5:9ab50662b3a10df3781df269b7ba241b',
-      'dist/example-yaml-4692130b/example_yaml_b_4692130b-2.0.0.tar.gz': 'md5:26cb998c37a2f1742c15030298ee5b86',
+      'dist/example-yaml-4692130b/example_yaml_b_4692130b-2.0.0.tar.gz': 'md5:364a1fa5c28c5d6cbd3ece996446b985',
       'dist/example-yaml-4692130b/example_yaml_b_4692130b-3.0.0-py3-none-any.whl': 'md5:9f737cd9adbcf989b2586a3d08f85414',
-      'dist/example-yaml-4692130b/example_yaml_b_4692130b-3.0.0.tar.gz': 'md5:f0e0f437f038780e3439d0963eea4033',
+      'dist/example-yaml-4692130b/example_yaml_b_4692130b-3.0.0.tar.gz': 'md5:7ee04b9b16fff97c4c61e1eaf8aa8948',
       'tree': '''
         test_build_test_scenarios_exam2
         ├── build


### PR DESCRIPTION
This adds `resolve_options.universal` to the packse schema, as well as an initial set of tests for the universal resolver.