### PR TITLE
ci: publish all scenarios

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Publish scenarios to GitHub Pages
         run: |
-          poetry run packse index build --no-hash scenarios/*.json
+          poetry run packse index build --no-hash scenarios/
 
           git fetch origin gh-pages
           git branch gh-pages FETCH_HEAD


### PR DESCRIPTION
Previously, we were only publishing `*.json` scenarios. But with the new
fork tests being writtin in TOML files in sub-directories, we should
just publish everything in `scenarios/`.
