### PR TITLE
scenarios: add tests for Requires-Python

### DIFF
--- a/scenarios/fork/requires-python-full-prerelease.toml
+++ b/scenarios/fork/requires-python-full-prerelease.toml
@@ -1,0 +1,22 @@
+name = "fork-requires-python-full-prerelease"
+description = '''
+This tests that a `Requires-Python` specifier will result in the
+exclusion of dependency specifications that cannot possibly satisfy it.
+
+In particular, this is tested via the `python_full_version` marker with
+a pre-release version.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires_python = ">=3.10"
+requires = [
+  "a==1.0.0 ; python_full_version == '3.9b1'",
+]
+
+[packages.a.versions."1.0.0"]

--- a/scenarios/fork/requires-python-full.toml
+++ b/scenarios/fork/requires-python-full.toml
@@ -1,0 +1,22 @@
+name = "fork-requires-python-full"
+description = '''
+This tests that a `Requires-Python` specifier will result in the
+exclusion of dependency specifications that cannot possibly satisfy it.
+
+In particular, this is tested via the `python_full_version` marker
+instead of the more common `python_version` marker.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires_python = ">=3.10"
+requires = [
+  "a==1.0.0 ; python_full_version == '3.9'",
+]
+
+[packages.a.versions."1.0.0"]

--- a/scenarios/fork/requires-python.toml
+++ b/scenarios/fork/requires-python.toml
@@ -1,0 +1,19 @@
+name = "fork-requires-python"
+description = '''
+This tests that a `Requires-Python` specifier will result in the
+exclusion of dependency specifications that cannot possibly satisfy it.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires_python = ">=3.10"
+requires = [
+  "a==1.0.0 ; python_version == '3.9'",
+]
+
+[packages.a.versions."1.0.0"]


### PR DESCRIPTION
This tests the interaction between `Requires-Python` and marker
expressions like `python_version` and `python_full_version`. In both of
these tests, the `a` dependency should be completely ignored because its
corresponding marker expression will never evaluate to true.
