### PR TITLE
scenarios: add Python environment to Requires-Python tests

### DIFF
--- a/scenarios/fork/requires-python-full-prerelease.toml
+++ b/scenarios/fork/requires-python-full-prerelease.toml
@@ -13,6 +13,9 @@ universal = true
 [expected]
 satisfiable = false
 
+[environment]
+python = "3.12"
+
 [root]
 requires_python = ">=3.10"
 requires = [

--- a/scenarios/fork/requires-python-full.toml
+++ b/scenarios/fork/requires-python-full.toml
@@ -13,6 +13,9 @@ universal = true
 [expected]
 satisfiable = false
 
+[environment]
+python = "3.12"
+
 [root]
 requires_python = ">=3.10"
 requires = [

--- a/scenarios/fork/requires-python.toml
+++ b/scenarios/fork/requires-python.toml
@@ -10,6 +10,9 @@ universal = true
 [expected]
 satisfiable = false
 
+[environment]
+python = "3.12"
+
 [root]
 requires_python = ">=3.10"
 requires = [


### PR DESCRIPTION
Without this, the tests generated in `uv` seem to default to using
`3.8`, which in turn doesn't work with a `Requires-Python` of 3.10.

We could change the version numbers here to work with the `3.8` default,
but it seems better to fully specify which Python is being used.
