### PR TITLE
scenarios: mark requires-python tests as satisfiable

### DIFF
--- a/scenarios/fork/requires-python-full-prerelease.toml
+++ b/scenarios/fork/requires-python-full-prerelease.toml
@@ -11,7 +11,7 @@ a pre-release version.
 universal = true
 
 [expected]
-satisfiable = false
+satisfiable = true
 
 [environment]
 python = "3.12"

--- a/scenarios/fork/requires-python-full.toml
+++ b/scenarios/fork/requires-python-full.toml
@@ -11,7 +11,7 @@ instead of the more common `python_version` marker.
 universal = true
 
 [expected]
-satisfiable = false
+satisfiable = true
 
 [environment]
 python = "3.12"

--- a/scenarios/fork/requires-python.toml
+++ b/scenarios/fork/requires-python.toml
@@ -8,7 +8,7 @@ exclusion of dependency specifications that cannot possibly satisfy it.
 universal = true
 
 [expected]
-satisfiable = false
+satisfiable = true
 
 [environment]
 python = "3.12"


### PR DESCRIPTION
This was an oversight when I initially wrote the tests. They are of
course satisfiable. We are just checking to make sure the `a` dependency
is filtered out by our `Requires-Python` specifier.
