### PR TITLE
scenarios: add test ensuring sibling dependencies get filtered in a fork

### DIFF
--- a/scenarios/fork/allows-non-conflicting-non-overlapping-dependencies.toml
+++ b/scenarios/fork/allows-non-conflicting-non-overlapping-dependencies.toml
@@ -1,0 +1,27 @@
+name = "fork-allows-non-conflicting-non-overlapping-dependencies"
+description = '''
+This test ensures that multiple non-conflicting but also
+non-overlapping dependency specifications with the same package name
+are allowed and supported.
+
+At time of writing, this provokes a fork in the resolver, but it
+arguably shouldn't since the requirements themselves do not conflict
+with one another. However, this does impact resolution. Namely, it
+leaves the `a>=1` fork free to choose `a==2.0.0` since it behaves as if
+the `a<2` constraint doesn't exist.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a>=1 ; sys_platform == 'linux'",
+  "a<2 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."1.0.0"]
+[packages.a.versions."2.0.0"]

--- a/scenarios/fork/allows-non-conflicting-repeated-dependencies.toml
+++ b/scenarios/fork/allows-non-conflicting-repeated-dependencies.toml
@@ -1,0 +1,26 @@
+name = "fork-allows-non-conflicting-repeated-dependencies"
+description = '''
+This test ensures that multiple non-conflicting dependency
+specifications with the same package name are allowed and supported.
+
+This test exists because the universal resolver forks itself based on
+duplicate dependency specifications by looking at package name. So at
+first glance, a case like this could perhaps cause an errant fork.
+While it's difficult to test for "does not create a fork" (at time of
+writing, the implementation does not fork), we can at least check that
+this case is handled correctly without issue. Namely, forking should
+only occur when there are duplicate dependency specifications with
+disjoint marker expressions.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["a>=1", "a<2"]
+
+[packages.a.versions."1.0.0"]
+[packages.a.versions."2.0.0"]

--- a/scenarios/fork/conflict-unsatisfiable.toml
+++ b/scenarios/fork/conflict-unsatisfiable.toml
@@ -1,0 +1,23 @@
+name = "fork-conflict-unsatisfiable"
+description = '''
+This test ensures that conflicting dependency specifications lead to an
+unsatisfiable result.
+
+In particular, this is a case that should not fork even though there
+are conflicting requirements because their marker expressions are
+overlapping. (Well, there aren't any marker expressions here, which
+means they are both unconditional.)
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires = ["a>=2", "a<2"]
+
+[packages.a.versions."1.0.0"]
+[packages.a.versions."2.0.0"]
+[packages.a.versions."3.0.0"]

--- a/scenarios/fork/filter-sibling-dependencies.toml
+++ b/scenarios/fork/filter-sibling-dependencies.toml
@@ -1,0 +1,39 @@
+name = "fork-filter-sibling-dependencies"
+description = '''
+This tests that sibling dependencies of a package that provokes a
+fork are correctly filtered out of forks where they are otherwise
+impossible.
+
+In this case, a previous version of the universal resolver would
+include both `b` and `c` in *both* of the forks produced by the
+conflicting dependency specifications on `a`. This in turn led to
+transitive dependency specifications on both `d==1.0.0` and `d==2.0.0`.
+Since the universal resolver only forks based on local conditions, this
+led to a failed resolution.
+
+The correct thing to do here is to ensure that `b` is only part of the
+`a==4.4.0` fork and `c` is only par of the `a==4.3.0` fork.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a==4.4.0 ; sys_platform == 'linux'",
+  "a==4.3.0 ; sys_platform == 'darwin'",
+  "b==1.0.0 ; sys_platform == 'linux'",
+  "c==1.0.0 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."4.3.0"]
+[packages.a.versions."4.4.0"]
+[packages.b.versions."1.0.0"]
+requires = ["d==1.0.0"]
+[packages.c.versions."1.0.0"]
+requires = ["d==2.0.0"]
+[packages.d.versions."1.0.0"]
+[packages.d.versions."2.0.0"]


### PR DESCRIPTION
This test is a reproduction of the issue observed in
https://github.com/astral-sh/uv/issues/4414, but "minimized" to a packse
scenario.