### PR TITLE
Add failing incomplete markers scenarios

### DIFF
--- a/scenarios/fork/incomplete-markers.toml
+++ b/scenarios/fork/incomplete-markers.toml
@@ -2,7 +2,9 @@ name = "fork-incomplete-markers"
 description = '''
 The root cause the resolver to fork over `a`, but the markers on the variant
 of `a` don't cover the entire marker space, they are missing Python 3.10.
-Later, we have a dependency this very hole, which we still need to select.
+Later, we have a dependency this very hole, which we still need to select,
+instead of having two forks around but without Python 3.10 and omitting
+`c` from the solution.
 '''
 
 [resolver_options]

--- a/scenarios/fork/incomplete-markers.toml
+++ b/scenarios/fork/incomplete-markers.toml
@@ -1,0 +1,29 @@
+name = "fork-incomplete-markers"
+description = '''
+The root cause the resolver to fork over `a`, but the markers on the variant
+of `a` don't cover the entire marker space, they are missing Python 3.10.
+Later, we have a dependency this very hole, which we still need to select.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a==1; python_version < '3.10'",
+  "a==2; python_version >= '3.11'",
+  "b",
+]
+
+[packages.a.versions."1.0.0"]
+[packages.a.versions."2.0.0"]
+
+[packages.b.versions."1.0.0"]
+requires = [
+  "c; python_version == '3.10'",
+]
+
+[packages.c.versions."1.0.0"]


### PR DESCRIPTION
We're currently (https://github.com/astral-sh/uv/issues/4732) failing to install `c` from the added scenario:

```
$ echo "fork-incomplete-markers-8137fed5" | uv pip compile --index-url http://127.0.0.1:3141 -p 3.9 --universal -
Resolved 4 packages in 38ms
# This file was autogenerated by uv via the following command:
#    uv pip compile -p 3.9 --universal -
fork-incomplete-markers-8137fed5==0.0.0
fork-incomplete-markers-a-8137fed5==1.0.0 ; python_version < '3.10'
    # via fork-incomplete-markers-8137fed5
fork-incomplete-markers-a-8137fed5==2.0.0 ; python_version >= '3.11'
    # via fork-incomplete-markers-8137fed5
fork-incomplete-markers-b-8137fed5==1.0.0
    # via fork-incomplete-markers-8137fed5
```

This is one particular scenario that we need to test for solving https://github.com/astral-sh/uv/issues/4732

I had to update the lockfile for the recent uv lockfile changes, split out to #199 which removes it from the diff here.