### PR TITLE
Add conflict in fork scenario

### DIFF
--- a/scenarios/fork/conflict-in-fork.toml
+++ b/scenarios/fork/conflict-in-fork.toml
@@ -1,0 +1,36 @@
+name = "conflict-in-fork"
+description = '''
+We have a conflict after forking. This scenario exists to test the error message.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires = [
+  "a>=2 ; sys_platform == 'linux'",
+  "a<2 ; sys_platform == 'darwin'",
+]
+
+[packages.a.versions."1.0.0"]
+requires = [
+  "b",
+  "c"
+]
+[packages.a.versions."2.0.0"]
+
+[packages.b.versions."1.0.0"]
+requires = [
+  "d==1",
+]
+
+[packages.c.versions."1.0.0"]
+requires = [
+  "d==2",
+]
+
+[packages.d.versions."1.0.0"]
+[packages.d.versions."2.0.0"]


### PR DESCRIPTION
Add a scenario where we fail after forking. The error message is already not bad:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because only fork-basic-b-03509d5c==1.0.0 is available and fork-basic-b-03509d5c==1.0.0 depends on fork-basic-d-03509d5c==1,
      we can conclude that all versions of fork-basic-b-03509d5c depend on fork-basic-d-03509d5c==1.
      And because fork-basic-c-03509d5c==1.0.0 depends on fork-basic-d-03509d5c==2 and only fork-basic-c-03509d5c==1.0.0 is
      available, we can conclude that all versions of fork-basic-b-03509d5c and all versions of fork-basic-c-03509d5c are
      incompatible.
      And because fork-basic-a-03509d5c{sys_platform == 'darwin'}==1.0.0 depends on fork-basic-b-03509d5c and fork-basic-c-03509d5c,
      we can conclude that fork-basic-a-03509d5c{sys_platform == 'darwin'}==1.0.0 cannot be used.
      And because only the following versions of fork-basic-a-03509d5c{sys_platform == 'darwin'} are available:
          fork-basic-a-03509d5c{sys_platform == 'darwin'}==1.0.0
          fork-basic-a-03509d5c{sys_platform == 'darwin'}>=2
      and fork-basic-03509d5c==0.0.0 depends on fork-basic-a-03509d5c{sys_platform == 'darwin'}<2, we can conclude that
      fork-basic-03509d5c==0.0.0 cannot be used.
      And because only fork-basic-03509d5c==0.0.0 is available and you require fork-basic-03509d5c, we can conclude that the
      requirements are unsatisfiable.
```