### PR TITLE
Add forking scenarios that are unstable with preferences

### DIFF
--- a/scenarios/fork/preferences-dependent-forking-conflicting.toml
+++ b/scenarios/fork/preferences-dependent-forking-conflicting.toml
@@ -1,0 +1,79 @@
+name = "preferences-dependent-forking-conflicting"
+description = '''
+Like `preferences-dependent-forking`, but when we don't fork the resolution fails.
+
+Consider a fresh run without preferences:
+* We start with cleaver 2
+* We fork
+* We reject cleaver 2
+* We find cleaver solution in fork 1 with foo 2 with bar 1
+* We find cleaver solution in fork 2 with foo 1 with bar 2
+* We write cleaver 1, foo 1, foo 2, bar 1 and bar 2 to the lockfile
+
+In a subsequent run, we read the preference cleaver 1 from the lockfile (the preferences for foo and bar don't matter):
+* We start with cleaver 1
+* We're in universal mode, cleaver requires foo 1, bar 1
+* foo 1 requires bar 2, conflict
+
+Design sketch:
+```text
+root -> clear, foo, bar
+# Cause a fork, then forget that version.
+cleaver 2 -> unrelated-dep==1; fork==1
+cleaver 2 -> unrelated-dep==2; fork==2
+cleaver 2 -> reject-cleaver-2
+# Allow different versions when forking, but force foo 1, bar 1 in universal mode without forking.
+cleaver 1 -> foo==1; fork==1
+cleaver 1 -> bar==1; fork==2
+# When we selected foo 1, bar 1 in universal mode for cleaver, this causes a conflict, otherwise we select bar 2.
+foo 1 -> bar==2
+```
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = false
+
+[root]
+requires = [
+  "cleaver",
+  # The reporter packages.
+  "foo",
+  "bar"
+]
+
+[packages.cleaver.versions."2.0.0"]
+requires = [
+  # Provoke a fork
+  "unrelated-dep==1; sys_platform == 'linux'",
+  "unrelated-dep==2; sys_platform != 'linux'",
+  "reject-cleaver-2",
+]
+
+[packages.reject-cleaver-2.versions."1.0.0"]
+requires = [
+  # That's a conflict with `cleaver==2`.
+  "unrelated-dep==3"
+]
+
+[packages.unrelated-dep.versions."1.0.0"]
+[packages.unrelated-dep.versions."2.0.0"]
+[packages.unrelated-dep.versions."3.0.0"]
+
+[packages.cleaver.versions."1.0.0"]
+requires = [
+  # Allow different versions when forking, but force foo 1, bar 1 in universal mode without forking.
+  "foo==1; sys_platform == 'linux'",
+  "bar==1; sys_platform != 'linux'"
+]
+
+[packages.foo.versions."1.0.0"]
+requires = [
+  # When we selected foo 1, bar 1 in universal mode for cleaver, this causes a conflict, otherwise we select bar 2.
+  "bar==2"
+]
+[packages.foo.versions."2.0.0"]
+[packages.bar.versions."1.0.0"]
+[packages.bar.versions."2.0.0"]

--- a/scenarios/fork/preferences-dependent-forking.toml
+++ b/scenarios/fork/preferences-dependent-forking.toml
@@ -1,0 +1,76 @@
+name = "preferences-dependent-forking"
+description = '''
+This test contains a scenario where the solution depends on whether we fork, and whether we fork depends on the
+preferences.
+
+Consider a fresh run without preferences:
+* We start with cleaver 2
+* We fork
+* We reject cleaver 2
+* We find cleaver solution in fork 1 with foo 2 with bar 1
+* We find cleaver solution in fork 2 with foo 1 with bar 2
+* We write cleaver 1, foo 1, foo 2, bar 1 and bar 2 to the lockfile
+
+In a subsequent run, we read the preference cleaver 1 from the lockfile (the preferences for foo and bar don't matter):
+* We start with cleaver 1
+* We're in universal mode, we resolve foo 1 and bar 1
+* We write cleaver 1 and bar 1 to the lockfile
+
+We call a resolution that's different on the second run to the first unstable.
+
+Design sketch:
+```text
+root -> clear, foo, bar
+# Cause a fork, then forget that version.
+cleaver 2 -> unrelated-dep==1; fork==1
+cleaver 2 -> unrelated-dep==2; fork==2
+cleaver 2 -> reject-cleaver-2
+# Allow different versions when forking, but force foo 1, bar 1 in universal mode without forking.
+cleaver 1 -> foo==1; fork==1
+cleaver 1 -> bar==1; fork==2
+```
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "cleaver",
+  # The reporter packages.
+  "foo",
+  "bar"
+]
+
+[packages.cleaver.versions."2.0.0"]
+requires = [
+  # Provoke a fork
+  "unrelated-dep==1; sys_platform == 'linux'",
+  "unrelated-dep==2; sys_platform != 'linux'",
+  "reject-cleaver-2",
+]
+
+[packages.reject-cleaver-2.versions."1.0.0"]
+requires = [
+  # That's a conflict with `cleaver==2`.
+  "unrelated-dep==3"
+]
+
+[packages.unrelated-dep.versions."1.0.0"]
+[packages.unrelated-dep.versions."2.0.0"]
+[packages.unrelated-dep.versions."3.0.0"]
+
+[packages.cleaver.versions."1.0.0"]
+requires = [
+  # Allow different versions when forking, but force foo 1, bar 1 in universal mode without forking.
+  "foo==1; sys_platform == 'linux'",
+  "bar==1; sys_platform != 'linux'"
+]
+
+[packages.foo.versions."1.0.0"]
+[packages.foo.versions."2.0.0"]
+[packages.bar.versions."1.0.0"]
+[packages.bar.versions."2.0.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -615,11 +615,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/e1/666771f0746f95c4df767ff98ff17fe55bb0c32ac88ec14ce0615a789330/watchfiles-0.22.0.tar.gz", hash = "sha256:988e981aaab4f3955209e7e28c7794acdb690be1efa7f16f8ea5aba7ffdadacb", size = 37900 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/10/a020809df82b46f5d30e7a8cfdebcec1eadc572aa06a60f42e50495c52c3/watchfiles-0.22.0-cp310-none-win32.whl", hash = "sha256:4b9f2a128a32a2c273d63eb1fdbf49ad64852fc38d15b34eaa3f7ca2f0d2b797", size = 272397 },
-    { url = "https://files.pythonhosted.org/packages/f8/79/9d7e16e805c721d5e5a3b1d1a3e798cc9b1282b799d7058a70ab506dc970/watchfiles-0.22.0-cp310-none-win_amd64.whl", hash = "sha256:2627a91e8110b8de2406d8b2474427c86f5a62bf7d9ab3654f541f319ef22bcb", size = 282074 },
-    { url = "https://files.pythonhosted.org/packages/56/d8/cede5a893d046865d5e3ec296258f8ad004e74c9c3bb76e0f604622742f1/watchfiles-0.22.0-cp311-none-win32.whl", hash = "sha256:b44b70850f0073b5fcc0b31ede8b4e736860d70e2dbf55701e05d3227a154a67", size = 272439 },
-    { url = "https://files.pythonhosted.org/packages/2b/8b/93f4e3ed0d578676b3c2e9d4ebf0b51237f4a96bbe3830b146662cb249da/watchfiles-0.22.0-cp311-none-win_amd64.whl", hash = "sha256:00f39592cdd124b4ec5ed0b1edfae091567c72c7da1487ae645426d1b0ffcad1", size = 281985 },
-    { url = "https://files.pythonhosted.org/packages/45/7b/de2713596f3a75edc7ab6c9c18fe24f6053e9fd6c3b360605817956cba3e/watchfiles-0.22.0-cp311-none-win_arm64.whl", hash = "sha256:3218a6f908f6a276941422b035b511b6d0d8328edd89a53ae8c65be139073f84", size = 269632 },
     { url = "https://files.pythonhosted.org/packages/ae/2c/efeae4b7b893b7241482a1eec87b6bdac0f49a04255bc1f2769cb75fdf43/watchfiles-0.22.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c7b978c384e29d6c7372209cbf421d82286a807bbcdeb315427687f8371c340a", size = 394129 },
     { url = "https://files.pythonhosted.org/packages/f8/a1/4f7dba44f55f23cdc4e775c44f5717db541481a563f47559df40f2c0ef58/watchfiles-0.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd4c06100bce70a20c4b81e599e5886cf504c9532951df65ad1133e508bf20be", size = 390232 },
     { url = "https://files.pythonhosted.org/packages/17/56/1678819b6250742d9bc399ab2969084f7f735ae5a7af2b41ae3f039295ca/watchfiles-0.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:425440e55cd735386ec7925f64d5dde392e69979d4c8459f6bb4e920210407f2", size = 1196309 },
@@ -633,10 +628,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/3b/de0bc91ad8e221d3ca5158f9e88531ed906d05d1c40f2a1d7222ea8e5a0d/watchfiles-0.22.0-cp312-none-win32.whl", hash = "sha256:581f0a051ba7bafd03e17127735d92f4d286af941dacf94bcf823b101366249e", size = 272472 },
     { url = "https://files.pythonhosted.org/packages/c9/d1/7a2404a9d52a85ee95d5f20b6a34a2708df84549d54fc8112308d502ed35/watchfiles-0.22.0-cp312-none-win_amd64.whl", hash = "sha256:aec83c3ba24c723eac14225194b862af176d52292d271c98820199110e31141e", size = 280951 },
     { url = "https://files.pythonhosted.org/packages/b6/35/0b7b7a0b43d4bdd0ee1829fb5a45bdd121611de9daf4c07367ba1c6a0904/watchfiles-0.22.0-cp312-none-win_arm64.whl", hash = "sha256:c668228833c5619f6618699a2c12be057711b0ea6396aeaece4ded94184304ea", size = 269776 },
-    { url = "https://files.pythonhosted.org/packages/0f/8c/3739eab8cf35127f11353301d0299e2b213c1096e8854cc772f18447d4fe/watchfiles-0.22.0-cp38-none-win32.whl", hash = "sha256:b610fb5e27825b570554d01cec427b6620ce9bd21ff8ab775fc3a32f28bba63e", size = 273808 },
-    { url = "https://files.pythonhosted.org/packages/db/15/5b16c3721813bcfb260cba0a86f524c23c6fb613129fec7e377a42f27b53/watchfiles-0.22.0-cp38-none-win_amd64.whl", hash = "sha256:fe82d13461418ca5e5a808a9e40f79c1879351fcaeddbede094028e74d836e86", size = 282021 },
-    { url = "https://files.pythonhosted.org/packages/09/91/1e20a8f70847195ab6a96ae955bc8674d1af33aece85ec0f5fcb71826dc4/watchfiles-0.22.0-cp39-none-win32.whl", hash = "sha256:8c3e3675e6e39dc59b8fe5c914a19d30029e36e9f99468dddffd432d8a7b1c93", size = 272988 },
-    { url = "https://files.pythonhosted.org/packages/4e/48/e42bff04ba199b6173755a924e3c62633bd8e2d4e0350c15e106ca3f12b4/watchfiles-0.22.0-cp39-none-win_amd64.whl", hash = "sha256:25c817ff2a86bc3de3ed2df1703e3d24ce03479b27bb4527c57e722f8554d971", size = 281923 },
 ]
 
 [[distribution]]


### PR DESCRIPTION
In the first scenario, `preferences-dependent-forking`, we show how the resolution can be different the second time because we don't fork anymore because the preferences from the lockfile make us skip the fork point. This scenario is inspired by the same happening in the `transformer` repo, where a single universal resolution leads to a more desirable lock without duplicate versions.

Consider a fresh run without preferences:
* We start with cleaver 2
* We fork
* We reject cleaver 2
* We find a cleaver 1 solution in fork 1 with foo 2 with bar 1
* We find a cleaver 1 solution in fork 2 with foo 1 with bar 2
* We write cleaver 1, foo 1, foo 2, bar 1 and bar 2 to the lockfile

In a subsequent run, we read the preference cleaver 1 from the lockfile (the preferences for foo and bar don't matter):
* We start with cleaver 1
* We're in universal mode, we resolve foo 1 and bar 1
* We write cleaver 1 and bar 1 to the lockfile

We call a resolution that's different between first and second run unstable.

Design sketch:
```text
root -> cleaver, foo, bar
# Cause a fork, then forget that version.
cleaver 2 -> unrelated-dep==1; fork==1
cleaver 2 -> unrelated-dep==2; fork==2
cleaver 2 -> reject-cleaver-2
# Allow diverging versions when forking, but force foo 1, bar 1 in universal mode without forking.
cleaver 1 -> foo==1; fork==1
cleaver 1 -> bar==1; fork==2
```

Let's try this out:

```toml
[project]
name = "dummy"
version = "0.1.0"
requires-python = ">=3.12"
dependencies = [
  "preferences-dependent-forking-5c5f76e6"
]

[tool.uv]
index-url = "http://127.0.0.1:3141/"
```

Cleanup and first, fresh run without preferences, on linux:
```console
$ rm -f uv.lock
$ uv venv -q
$ cargo run -q -- sync --preview
Resolved 6 packages in 647ms
Built dummy @ file:///home/konsti/projects/uv/debug/dummy
Built preferences-dependent-forking-5c5f76e6==0.0.0
Prepared 2 packages in 457ms
Installed 5 packages in 1ms
+ dummy==0.1.0 (from file:///home/konsti/projects/uv/debug/dummy)
+ preferences-dependent-forking-5c5f76e6==0.0.0
+ preferences-dependent-forking-bar-5c5f76e6==1.0.0
+ preferences-dependent-forking-cleaver-5c5f76e6==1.0.0
+ preferences-dependent-forking-foo-5c5f76e6==2.0.0
```

Second run, using the preferences from the lockfile:
```console
$ cargo run -q -- sync --preview
  Resolved 5 packages in 113ms
  Uninstalled 1 package in 0.57ms
  Installed 1 package in 1ms
- preferences-dependent-forking-foo-5c5f76e6==2.0.0
+ preferences-dependent-forking-foo-5c5f76e6==1.0.0
```

The logs confirm that in the first run with fork, while in the second we don't.

In the second scenario `preferences-dependent-forking-conflicting`, we add `foo 1 -> bar==2` so that the resolving cleaver 1 fails without forking:

```toml
[project]
name = "dummy"
version = "0.1.0"
requires-python = ">=3.12"
dependencies = [
  "preferences-dependent-forking-conflicting-5f0792c1"
]

[tool.uv]
index-url = "http://127.0.0.1:3141/"
```

Cleanup and first, fresh run, on linux:
```console
$ rm -f uv.lock
$ uv venv -q
$ cargo run -q -- sync --preview
Resolved 7 packages in 166ms
   Built dummy @ file:///home/konsti/projects/uv/debug/dummy
Prepared 1 package in 489ms
Installed 5 packages in 1ms
 + dummy==0.1.0 (from file:///home/konsti/projects/uv/debug/dummy)
 + preferences-dependent-forking-conflicting-5f0792c1==0.0.0
 + preferences-dependent-forking-conflicting-bar-5f0792c1==2.0.0
 + preferences-dependent-forking-conflicting-cleaver-5f0792c1==1.0.0
 + preferences-dependent-forking-conflicting-foo-5f0792c1==2.0.0
```

In the second run, we're using the preferences from the lockfile. We reject preference cleaver 1 in universal mode, then move to cleaver 2, fork, and fail in one of the forks by the cleaver 2 rejecting package:
```console
$ cargo run -q -- sync --preview
  × No solution found when resolving dependencies for split (sys_platform != 'linux'):
  ╰─▶ Because preferences-dependent-forking-conflicting-foo-5f0792c1==1.0.0
      depends on preferences-dependent-forking-conflicting-bar-5f0792c1==2 and
      preferences-dependent-forking-conflicting-cleaver-5f0792c1==1.0.0 depends on
      preferences-dependent-forking-conflicting-foo-5f0792c1{sys_platform == 'linux'}==1, we can
      conclude that preferences-dependent-forking-conflicting-cleaver-5f0792c1==1.0.0 depends on
      preferences-dependent-forking-conflicting-bar-5f0792c1==2.
      And because preferences-dependent-forking-conflicting-cleaver-5f0792c1==1.0.0 depends on
      preferences-dependent-forking-conflicting-bar-5f0792c1{sys_platform != 'linux'}==1 and only the following
      versions of preferences-dependent-forking-conflicting-cleaver-5f0792c1 are available:
          preferences-dependent-forking-conflicting-cleaver-5f0792c1==1.0.0
          preferences-dependent-forking-conflicting-cleaver-5f0792c1==2.0.0
      we can conclude that preferences-dependent-forking-conflicting-cleaver-5f0792c1<2.0.0 cannot be used. (1)

      Because preferences-dependent-forking-conflicting-reject-cleaver-2-5f0792c1==1.0.0
      depends on preferences-dependent-forking-conflicting-unrelated-dep-5f0792c1==3 and only
      preferences-dependent-forking-conflicting-reject-cleaver-2-5f0792c1==1.0.0 is available, we can
      conclude that all versions of preferences-dependent-forking-conflicting-reject-cleaver-2-5f0792c1 and
      preferences-dependent-forking-conflicting-unrelated-dep-5f0792c1{sys_platform != 'linux'}==2.0.0 are
      incompatible.
      And because preferences-dependent-forking-conflicting-cleaver-5f0792c1==2.0.0 depends on
      preferences-dependent-forking-conflicting-unrelated-dep-5f0792c1{sys_platform != 'linux'}==2
      and preferences-dependent-forking-conflicting-reject-cleaver-2-5f0792c1, we can conclude that
      preferences-dependent-forking-conflicting-cleaver-5f0792c1==2.0.0 cannot be used.
      And because we know from (1) that preferences-dependent-forking-conflicting-cleaver-5f0792c1<2.0.0 cannot
      be used, we can conclude that all versions of preferences-dependent-forking-conflicting-cleaver-5f0792c1
      cannot be used.
      And because preferences-dependent-forking-conflicting-5f0792c1==0.0.0 depends on
      preferences-dependent-forking-conflicting-cleaver-5f0792c1, we can conclude that
      preferences-dependent-forking-conflicting-5f0792c1==0.0.0 cannot be used.
      And because only preferences-dependent-forking-conflicting-5f0792c1==0.0.0 is available and dummy==0.1.0
      depends on preferences-dependent-forking-conflicting-5f0792c1, we can conclude that dummy==0.1.0 cannot
      be used.
      And because only dummy==0.1.0 is available and you require dummy, we can conclude that the requirements
      are unsatisfiable.
```

The logs confirm that we fork in both runs.

I don't know whether this scenario should be tagged `satisfiable` yet or not.