### PR TITLE
Add bistable preference-dependent forking scenario

### DIFF
--- a/scenarios/fork/preferences-dependent-forking-bistable.toml
+++ b/scenarios/fork/preferences-dependent-forking-bistable.toml
@@ -1,0 +1,85 @@
+name = "preferences-dependent-forking-bistable"
+description = '''
+This test contains a bistable resolution scenario when not using ahead-of-time
+splitting of resolution forks: We meet one of two fork points depending on the
+preferences, creating a resolution whose preferences lead us the other fork
+point.
+
+In the first case, we are in cleaver 2 and fork on `sys_platform`, in the
+second case, we are in foo 1 or bar 1 amd fork over `os_name`.
+
+First case: We select cleaver 2, fork on `sys_platform`, we reject cleaver 2
+(missing fork `os_name`), we select cleaver 1 and don't fork on `os_name` in
+`fork-if-not-forked`, done.
+Second case: We have preference cleaver 1, fork on `os_name` in
+`fork-if-not-forked`, we reject cleaver 1, we select cleaver 2, we fork on
+`sys_platform`, we accept cleaver 2 since we forked on `os_name`, done.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "cleaver",
+]
+
+[packages.cleaver.versions."2.0.0"]
+requires = [
+  # Provoke a fork on sys_platform.
+  "fork-sys-platform==1; sys_platform == 'linux'",
+  "fork-sys-platform==2; sys_platform != 'linux'",
+  # Reject cleaver 2 if we didn't fork on os_name, without forking on os_name.
+  "reject-cleaver2==1; os_name == 'posix'",
+  "reject-cleaver2-proxy",
+]
+
+[packages.fork-sys-platform.versions."1.0.0"]
+[packages.fork-sys-platform.versions."2.0.0"]
+
+[packages.reject-cleaver2-proxy.versions."1.0.0"]
+requires = [
+  "reject-cleaver2==2; os_name != 'posix'"
+]
+
+[packages.reject-cleaver2.versions."1.0.0"]
+[packages.reject-cleaver2.versions."2.0.0"]
+
+[packages.cleaver.versions."1.0.0"]
+requires = [
+  # Provoke a fork on os-name, but only if we didn't fork before.
+  "fork-if-not-forked!=2; sys_platform == 'linux'",
+  "fork-if-not-forked-proxy; sys_platform != 'linux'",
+  # Reject cleaver 1 if we didn't fork on sys_platform, without forking on sys_platform.
+  "reject-cleaver1==1; sys_platform == 'linux'",
+  "reject-cleaver1-proxy"
+]
+
+[packages.fork-if-not-forked-proxy.versions."1.0.0"]
+requires = [
+  "fork-if-not-forked!=3"
+]
+
+[packages.reject-cleaver1-proxy.versions."1.0.0"]
+requires = [
+  "reject-cleaver1==2; sys_platform != 'linux'",
+]
+
+[packages.reject-cleaver1.versions."1.0.0"]
+[packages.reject-cleaver1.versions."2.0.0"]
+
+[packages.fork-os-name.versions."1.0.0"]
+[packages.fork-os-name.versions."2.0.0"]
+
+[packages.fork-if-not-forked.versions."1.0.0"]
+requires = [
+  # Actually provoke the fork for cleaver 1.
+  "fork-os-name==1; os_name == 'posix'",
+  "fork-os-name==2; os_name != 'posix'",
+  "reject-cleaver1-proxy"
+]
+[packages.fork-if-not-forked.versions."2.0.0"]
+[packages.fork-if-not-forked.versions."3.0.0"]

--- a/scenarios/fork/preferences-dependent-forking-tristable.toml
+++ b/scenarios/fork/preferences-dependent-forking-tristable.toml
@@ -1,0 +1,99 @@
+name = "preferences-dependent-forking-tristable"
+description = '''
+This test case is like "preferences-dependent-forking-bistable", but with three
+states instead of two. The first two locks are in a different state, then we
+enter the tristable state.
+
+It's not polished, but it's useful to have something with a higher period
+than 2 in our test suite.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "cleaver",
+  "foo",
+  "bar"
+]
+
+[packages.cleaver.versions."2.0.0"]
+requires = [
+  "unrelated-dep==1; sys_platform == 'linux'",
+  "unrelated-dep==2; sys_platform != 'linux'",
+  "a",
+  "b",
+]
+
+[packages.a.versions."1.0.0"]
+requires = [
+  "unrelated-dep3==1; os_name == 'posix'"
+]
+
+[packages.b.versions."1.0.0"]
+requires = [
+  "unrelated-dep3==2; os_name != 'posix'"
+]
+
+[packages.reject-cleaver-2.versions."1.0.0"]
+requires = [
+  "unrelated-dep3==3"
+]
+
+[packages.unrelated-dep.versions."1.0.0"]
+[packages.unrelated-dep.versions."2.0.0"]
+[packages.unrelated-dep.versions."3.0.0"]
+
+[packages.unrelated-dep3.versions."1.0.0"]
+[packages.unrelated-dep3.versions."2.0.0"]
+[packages.unrelated-dep3.versions."3.0.0"]
+
+[packages.cleaver.versions."1.0.0"]
+requires = [
+  "foo==1; sys_platform == 'linux'",
+  "bar==1; sys_platform != 'linux'"
+]
+
+[packages.foo.versions."1.0.0"]
+requires = [
+  "c!=3; sys_platform == 'linux'",
+  "c!=2; sys_platform != 'linux'",
+  "reject-cleaver-1"
+]
+[packages.foo.versions."2.0.0"]
+[packages.bar.versions."1.0.0"]
+requires = [
+  "c!=3; sys_platform == 'linux'",
+  "d; sys_platform != 'linux'",
+  "reject-cleaver-1"
+]
+[packages.bar.versions."2.0.0"]
+
+[packages.reject-cleaver-1.versions."1.0.0"]
+requires = [
+  "unrelated-dep2==1; sys_platform == 'linux'",
+  "unrelated-dep2==2; sys_platform != 'linux'",
+]
+
+[packages.unrelated-dep2.versions."1.0.0"]
+[packages.unrelated-dep2.versions."2.0.0"]
+[packages.unrelated-dep2.versions."3.0.0"]
+
+
+[packages.c.versions."1.0.0"]
+requires = [
+  "unrelated-dep2==1; os_name == 'posix'",
+  "unrelated-dep2==2; os_name != 'posix'",
+  "reject-cleaver-1"
+]
+[packages.c.versions."2.0.0"]
+[packages.c.versions."3.0.0"]
+
+[packages.d.versions."1.0.0"]
+requires = [
+  "c!=2"
+]


### PR DESCRIPTION
Another test for the resolver instability.

> This test contains a bistable resolution scenario when not using ahead-of-time
> splitting of resolution forks: We meet one of two fork points depending on the
> preferences, creating a resolution whose preferences lead us the other fork
> point.
>
> In the first case, we are in cleaver 2 and fork on `sys_platform`, in the
> second case, we are in foo 1 or bar 1 amd fork over `os_name`.
>
> First case: We select cleaver 2, fork on `sys_platform`, we reject cleaver 2
> (missing fork `os_name`), we select cleaver 1 and don't fork on `os_name` in
> `fork-if-not-forked`, done.
> Second case: We have preference cleaver 1, fork on `os_name` in
> `fork-if-not-forked`, we reject cleaver 1, we select cleaver 2, we fork on
> `sys_platform`, we accept cleaver 2 since we forked on `os_name`, done.

I've also included a tristable system with two iterations lead-up time that is accidentally created. It's not documented, but i wouldn't waste such a cursed scenario.

With uv 0.2.31:

```
$ uv venv && rm -f uv.lock && uv lock --preview --refresh && echo "===" && uv lock --preview && echo "===" && uv lock --preview && echo "===" && uv lock --preview
Using Python 3.12.3 interpreter at: /home/konsti/.local/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
Resolved 9 packages in 362ms
===
Resolved 8 packages in 140ms
Updated preferences-dependent-forking-bistable-cleaver v1.0.0 -> v2.0.0
Removed preferences-dependent-forking-bistable-fork-if-not-forked v2.0.0, v3.0.0
Removed preferences-dependent-forking-bistable-fork-if-not-forked-proxy v1.0.0
Added preferences-dependent-forking-bistable-fork-sys-platform v1.0.0, v2.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver1 v1.0.0, v2.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver1-proxy v1.0.0
Added preferences-dependent-forking-bistable-reject-cleaver2 v1.0.0, v2.0.0
Added preferences-dependent-forking-bistable-reject-cleaver2-proxy v1.0.0
===
Resolved 9 packages in 3ms
Updated preferences-dependent-forking-bistable-cleaver v2.0.0 -> v1.0.0
Added preferences-dependent-forking-bistable-fork-if-not-forked v2.0.0, v3.0.0
Added preferences-dependent-forking-bistable-fork-if-not-forked-proxy v1.0.0
Removed preferences-dependent-forking-bistable-fork-sys-platform v1.0.0, v2.0.0
Added preferences-dependent-forking-bistable-reject-cleaver1 v1.0.0, v2.0.0
Added preferences-dependent-forking-bistable-reject-cleaver1-proxy v1.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver2 v1.0.0, v2.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver2-proxy v1.0.0
===
Resolved 8 packages in 4ms
Updated preferences-dependent-forking-bistable-cleaver v1.0.0 -> v2.0.0
Removed preferences-dependent-forking-bistable-fork-if-not-forked v2.0.0, v3.0.0
Removed preferences-dependent-forking-bistable-fork-if-not-forked-proxy v1.0.0
Added preferences-dependent-forking-bistable-fork-sys-platform v1.0.0, v2.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver1 v1.0.0, v2.0.0
Removed preferences-dependent-forking-bistable-reject-cleaver1-proxy v1.0.0
Added preferences-dependent-forking-bistable-reject-cleaver2 v1.0.0, v2.0.0
Added preferences-dependent-forking-bistable-reject-cleaver2-proxy v1.0.0
```