### PR TITLE
Update deprecated actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,13 +26,13 @@ jobs:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test-build')
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-checks:
-    name: python-${{ matrix.python-version }}, ${{ matrix.os }}
+    name: Check python-${{ matrix.python-version }}, ${{ matrix.os }}
     timeout-minutes: 5
 
     strategy:
@@ -45,6 +45,7 @@ jobs:
 
   typos:
     runs-on: ubuntu-latest
+    name: Check typos
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@master

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish-packages:
-    name: python-${{ matrix.python-version }}, ${{ matrix.os }}
+    name: Publish python-${{ matrix.python-version }}, ${{ matrix.os }}
 
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -45,10 +45,10 @@ jobs:
     name: Publish scenarios
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   python-tests:
-    name: python-${{ matrix.python-version }}, ${{ matrix.os }}
+    name: Test python-${{ matrix.python-version }}, ${{ matrix.os }}
 
     strategy:
       matrix:

--- a/scenarios/fork/fork-upgrade.toml
+++ b/scenarios/fork/fork-upgrade.toml
@@ -1,0 +1,30 @@
+name = "fork-upgrade"
+description = '''
+This test checks that we discard fork markers when using `--upgrade`.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "foo",
+]
+
+[packages.foo.versions."1.0.0"]
+requires = [
+  # Provoke a fork
+  "bar==1; sys_platform == 'linux'",
+  "bar==2; sys_platform != 'linux'",
+]
+[packages.foo.versions."2.0.0"]
+requires = [
+  # No fork
+  "bar==2",
+]
+
+[packages.bar.versions."1.0.0"]
+[packages.bar.versions."2.0.0"]

--- a/scenarios/tag-and-markers.json
+++ b/scenarios/tag-and-markers.json
@@ -1,0 +1,115 @@
+[
+    {
+        "name": "unreachable-package",
+        "description": "`c` is not reachable due to the markers, it should be excluded from the lockfile",
+        "root": {
+            "requires": [
+                "a==1.0.0; sys_platform == 'win32'"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires": ["b==1.0.0; sys_platform == 'linux'"]
+                    }
+                }
+            },
+            "b": {
+                "versions": {
+                    "1.0.0": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true
+        },
+        "resolver_options": {
+            "universal": true
+        }
+    },
+    {
+        "name": "unreachable-wheels",
+        "description": "Check that we only include wheels that match the platform markers",
+        "root": {
+            "requires": [
+                "a==1.0.0; sys_platform == 'win32'",
+                "b==1.0.0; sys_platform == 'linux'",
+                "c==1.0.0; sys_platform == 'darwin'"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "wheel_tags": [
+                            "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+                            "cp312-cp312-musllinux_1_1_armv7l",
+                            "cp312-cp312-win_amd64",
+                            "cp312-cp312-macosx_14_0_x86_64"
+                        ]
+                    }
+                }
+            },
+            "b": {
+                "versions": {
+                    "1.0.0": {
+                        "wheel_tags": [
+                            "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+                            "cp312-cp312-musllinux_1_1_armv7l",
+                            "cp312-cp312-win_amd64",
+                            "cp312-cp312-macosx_14_0_x86_64"
+                        ]
+                    }
+                }
+            },
+            "c": {
+                "versions": {
+                    "1.0.0": {
+                        "wheel_tags": [
+                            "cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64",
+                            "cp312-cp312-musllinux_1_1_armv7l",
+                            "cp312-cp312-win_amd64",
+                            "cp312-cp312-macosx_14_0_x86_64"
+                        ]
+                    }
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true
+        },
+        "resolver_options": {
+            "universal": true
+        }
+    },
+    {
+        "name": "requires-python-wheels",
+        "description": "Check that we only include wheels that match the required Python version",
+        "root": {
+            "requires_python": ">=3.10",
+            "requires": [
+                "a==1.0.0"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "wheel_tags": [
+                            "cp311-cp311-any",
+                            "cp310-cp310-any",
+                            "cp39-cp39-any"
+                        ]
+                    }
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true
+        },
+        "resolver_options": {
+            "universal": true
+        }
+    }
+]

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,6 +14,7 @@ from itertools import islice
 from pathlib import Path
 
 import pytest
+
 from packse import __development_base_path__
 
 MAX_FILE_LENGTH = 500

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+
 from packse import __development_base_path__
 from packse.scenario import load_scenario, scenario_hash
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,4 +1,5 @@
 import pytest
+
 from packse import __development_base_path__
 
 from .common import snapshot_command

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,5 @@
 import pytest
+
 from packse import __development_base_path__
 
 from .common import snapshot_command

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Generator
 
 import pytest
+
 from packse import __development_base_path__
 
 from .common import snapshot_command

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -3,6 +3,7 @@ Tests a subset of included scenarios
 """
 
 import pytest
+
 from packse import __development_base_path__
 
 from .common import snapshot_command

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,4 +1,5 @@
 import pytest
+
 from packse import __development_base_path__
 
 from .common import snapshot_command

--- a/uv.lock
+++ b/uv.lock
@@ -1,7 +1,7 @@
 version = 1
 requires-python = ">=3.12"
 
-[[distribution]]
+[[package]]
 name = "anyio"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -14,7 +14,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/a2/10639a79341f6c019dedc95bd48a4928eed9f1d1197f4c04f546fc7ae0ff/anyio-4.4.0-py3-none-any.whl", hash = "sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7", size = 86780 },
 ]
 
-[[distribution]]
+[[package]]
 name = "certifi"
 version = "2024.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -23,7 +23,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90", size = 162960 },
 ]
 
-[[distribution]]
+[[package]]
 name = "cffi"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -44,7 +44,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/63/e285470a4880a4f36edabe4810057bd4b562c6ddcc165eacf9c3c7210b40/cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235", size = 181956 },
 ]
 
-[[distribution]]
+[[package]]
 name = "charset-normalizer"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -68,7 +68,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc", size = 48543 },
 ]
 
-[[distribution]]
+[[package]]
 name = "chevron-blue"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -77,7 +77,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/f1/b959f5888a68017736384b90b8bb4a5ba78b32b3df7b5e31a2446ec17cba/chevron_blue-0.2.1-py3-none-any.whl", hash = "sha256:ab9accbb5c5f42ba224821904a4f14642cbc6d117706a8b105723bc80e733dea", size = 10306 },
 ]
 
-[[distribution]]
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -86,7 +86,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
 
-[[distribution]]
+[[package]]
 name = "cryptography"
 version = "42.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -120,7 +120,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/7b/b0d330852dd5953daee6b15f742f15d9f18e9c0154eb4cfcc8718f0436da/cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a", size = 2886038 },
 ]
 
-[[distribution]]
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -129,7 +129,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408 },
 ]
 
-[[distribution]]
+[[package]]
 name = "hatchling"
 version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -144,7 +144,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/8b/90e80904fdc24ce33f6fc6f35ebd2232fe731a8528a22008458cf197bc4d/hatchling-1.25.0-py3-none-any.whl", hash = "sha256:b47948e45d4d973034584dd4cb39c14b6a70227cf287ab7ec0ad7983408a882c", size = 84077 },
 ]
 
-[[distribution]]
+[[package]]
 name = "idna"
 version = "3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -153,7 +153,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0", size = 66836 },
 ]
 
-[[distribution]]
+[[package]]
 name = "importlib-metadata"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -165,7 +165,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/ef/38766b2edb096260d9b1b6ad35adaa0bce3b0567abb452b21eb074af88c4/importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f", size = 24769 },
 ]
 
-[[distribution]]
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -174,7 +174,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
 ]
 
-[[distribution]]
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -186,7 +186,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777 },
 ]
 
-[[distribution]]
+[[package]]
 name = "jaraco-context"
 version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -195,7 +195,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/40/11b7bc1898cf1dcb87ccbe09b39f5088634ac78bb25f3383ff541c2b40aa/jaraco.context-5.3.0-py3-none-any.whl", hash = "sha256:3e16388f7da43d384a1a7cd3452e72e14732ac9fe459678773a3608a812bf266", size = 6527 },
 ]
 
-[[distribution]]
+[[package]]
 name = "jaraco-functools"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -207,7 +207,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/ac/d0bf0d37a9f95f69a5efc5685d9166ee34a664d3cd29a9c139989512fe14/jaraco.functools-4.0.1-py3-none-any.whl", hash = "sha256:3b24ccb921d6b593bdceb56ce14799204f473976e2a9d4b15b04d0f2c2326664", size = 9789 },
 ]
 
-[[distribution]]
+[[package]]
 name = "jeepney"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -216,7 +216,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755", size = 48435 },
 ]
 
-[[distribution]]
+[[package]]
 name = "keyring"
 version = "25.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -233,7 +233,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/91/901f5cfeaaea04cf15f5ddf41ee053a5c9e389166477a3427fcfd055e1d9/keyring-25.2.1-py3-none-any.whl", hash = "sha256:2458681cdefc0dbc0b7eb6cf75d0b98e59f9ad9b2d4edd319d18f68bdca95e50", size = 38315 },
 ]
 
-[[distribution]]
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -245,7 +245,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
 ]
 
-[[distribution]]
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -254,7 +254,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
-[[distribution]]
+[[package]]
 name = "more-itertools"
 version = "10.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -263,7 +263,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/23/2d1cdb0427aecb2b150dc2ac2d15400990c4f05585b3fbc1b5177d74d7fb/more_itertools-10.3.0-py3-none-any.whl", hash = "sha256:ea6a02e24a9161e51faad17a8782b92a0df82c12c1c8886fec7f0c3fa1a1b320", size = 59245 },
 ]
 
-[[distribution]]
+[[package]]
 name = "msgspec"
 version = "0.18.6"
 source = { registry = "https://pypi.org/simple" }
@@ -278,7 +278,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/76/30d8f152299f65c85c46a2cbeaf95ad1d18516b5ce730acdaef696d4cfe6/msgspec-0.18.6-cp312-cp312-win_amd64.whl", hash = "sha256:1003c20bfe9c6114cc16ea5db9c5466e49fae3d7f5e2e59cb70693190ad34da0", size = 187184 },
 ]
 
-[[distribution]]
+[[package]]
 name = "nh3"
 version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -301,7 +301,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl", hash = "sha256:8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844", size = 579012 },
 ]
 
-[[distribution]]
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -310,7 +310,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985 },
 ]
 
-[[distribution]]
+[[package]]
 name = "packse"
 version = "0.0.0"
 source = { editable = "." }
@@ -323,7 +323,7 @@ dependencies = [
     { name = "twine" },
 ]
 
-[distribution.optional-dependencies]
+[package.optional-dependencies]
 index = [
     { name = "pypiserver" },
 ]
@@ -332,14 +332,34 @@ serve = [
     { name = "watchfiles" },
 ]
 
-[distribution.dev-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "psutil" },
     { name = "pytest" },
     { name = "syrupy" },
 ]
 
-[[distribution]]
+[package.metadata]
+requires-dist = [
+    { name = "chevron-blue", specifier = ">=0.2.1" },
+    { name = "hatchling", specifier = ">=1.20.0" },
+    { name = "msgspec", specifier = ">=0.18.4" },
+    { name = "packse", extras = ["index"], marker = "extra == 'serve'" },
+    { name = "pypiserver", marker = "extra == 'index'", specifier = ">=2.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "setuptools", specifier = ">=69.1.1" },
+    { name = "twine", specifier = ">=4.0.2" },
+    { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "psutil", specifier = ">=5.9.7" },
+    { name = "pytest", specifier = ">=7.4.3" },
+    { name = "syrupy", specifier = ">=4.6.0" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -348,7 +368,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pip"
 version = "24.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -357,7 +377,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/54/0c1c068542cee73d8863336e974fc881e608d0170f3af15d0c0f28644531/pip-24.1.2-py3-none-any.whl", hash = "sha256:7cd207eed4c60b0f411b444cd1464198fe186671c323b6cd6d433ed80fc9d247", size = 1824406 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pkginfo"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -366,7 +386,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl", hash = "sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097", size = 30392 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -375,7 +395,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
-[[distribution]]
+[[package]]
 name = "psutil"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -392,7 +412,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/06/63872a64c312a24fb9b4af123ee7007a306617da63ff13bcc1432386ead7/psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0", size = 251988 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -401,7 +421,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pygments"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -410,7 +430,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pypiserver"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -423,7 +443,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/1f/846aa2ea6e264efc2de4f293a2f548b8ac932041e1e0ab91eb81426983a7/pypiserver-2.1.1-py2.py3-none-any.whl", hash = "sha256:8c7ed96b2f76f2843e4a27002846bd7ebb7217e143cf60456ee6fa2a415c2d73", size = 92886 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pytest"
 version = "8.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -438,7 +458,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/e7/81ebdd666d3bff6670d27349b5053605d83d55548e6bd5711f3b0ae7dd23/pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343", size = 339873 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -447,7 +467,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/bc/78b2c00cc64c31dbb3be42a0e8600bcebc123ad338c3b714754d668c7c2d/pywin32_ctypes-0.2.2-py3-none-any.whl", hash = "sha256:bf490a1a709baf35d688fe0ecf980ed4de11d2b3e37b51e5442587a75d9957e7", size = 30152 },
 ]
 
-[[distribution]]
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -462,7 +482,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/9f/fbade56564ad486809c27b322d0f7e6a89c01f6b4fe208402e90d4443a99/PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df", size = 138675 },
 ]
 
-[[distribution]]
+[[package]]
 name = "readme-renderer"
 version = "44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -476,7 +496,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310 },
 ]
 
-[[distribution]]
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -491,7 +511,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
 ]
 
-[[distribution]]
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -503,7 +523,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
 ]
 
-[[distribution]]
+[[package]]
 name = "rfc3986"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -512,7 +532,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326 },
 ]
 
-[[distribution]]
+[[package]]
 name = "rich"
 version = "13.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -525,7 +545,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/87/67/a37f6214d0e9fe57f6ae54b2956d550ca8365857f42a1ce0392bb21d9410/rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222", size = 240681 },
 ]
 
-[[distribution]]
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -538,7 +558,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221 },
 ]
 
-[[distribution]]
+[[package]]
 name = "setuptools"
 version = "70.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -547,7 +567,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/15/88e46eb9387e905704b69849618e699dc2f54407d8953cc4ec4b8b46528d/setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc", size = 931070 },
 ]
 
-[[distribution]]
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -556,7 +576,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
 ]
 
-[[distribution]]
+[[package]]
 name = "syrupy"
 version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -568,7 +588,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/37/c1a22c32b6736c7f0345b9573d6874c94a68aff19ca8d1015e3d5f8a91e1/syrupy-4.6.1-py3-none-any.whl", hash = "sha256:203e52f9cb9fa749cf683f29bd68f02c16c3bc7e7e5fe8f2fc59bdfe488ce133", size = 47211 },
 ]
 
-[[distribution]]
+[[package]]
 name = "trove-classifiers"
 version = "2024.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -577,7 +597,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/b0/09794439a62a7dc18bffdbf145aaf50297fd994890b11da27a13e376b947/trove_classifiers-2024.7.2-py3-none-any.whl", hash = "sha256:ccc57a33717644df4daca018e7ec3ef57a835c48e96a1e71fc07eb7edac67af6", size = 13468 },
 ]
 
-[[distribution]]
+[[package]]
 name = "twine"
 version = "5.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -597,7 +617,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl", hash = "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997", size = 38650 },
 ]
 
-[[distribution]]
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -606,7 +626,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472", size = 121444 },
 ]
 
-[[distribution]]
+[[package]]
 name = "watchfiles"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -630,7 +650,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/35/0b7b7a0b43d4bdd0ee1829fb5a45bdd121611de9daf4c07367ba1c6a0904/watchfiles-0.22.0-cp312-none-win_arm64.whl", hash = "sha256:c668228833c5619f6618699a2c12be057711b0ea6396aeaece4ded94184304ea", size = 269776 },
 ]
 
-[[distribution]]
+[[package]]
 name = "zipp"
 version = "3.19.2"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
CI was complaining:

> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3, actions/setup-python@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/