### PR TITLE
Fix python-less-than-current

### DIFF
--- a/scenarios/requires-python.json
+++ b/scenarios/requires-python.json
@@ -41,7 +41,8 @@
             }
         },
         "expected": {
-            "satisfiable": false
+            "satisfiable": true,
+            "explanation": "We ignore the upper bound on Python requirements"
         }
     },
     {


### PR DESCRIPTION
We ignore upper bounds in the requires-python of dependencies, so this test should now pass.