### PR TITLE
Modify line breaks for patch test

### DIFF
--- a/scenarios/fork/requires-python-patch-overlap.toml
+++ b/scenarios/fork/requires-python-patch-overlap.toml
@@ -5,10 +5,10 @@ patch version will not result in excluded a dependency specification
 with a `python_version == '3.10'` marker.
 
 This is a regression test for the universal resolver where it would
-convert a `Requires-Python: >=3.10.1` specifier into a `python_version
->= '3.10.1'` marker expression, which would be considered disjoint
-with `python_version == '3.10'`. Thus, the dependency `a` below was
-erroneously excluded. It should be included.
+convert a `Requires-Python: >=3.10.1` specifier into a
+`python_version >= '3.10.1'` marker expression, which would be
+considered disjoint with `python_version == '3.10'`. Thus, the
+dependency `a` below was erroneously excluded. It should be included.
 '''
 
 [resolver_options]


### PR DESCRIPTION
For whatever reason this is confusing Clippy on 1.81.