### PR TITLE
Remove deprecate pkg_resources

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Check release version
         run: |
-          installed=$(python3 -c "import pkg_resources; print(pkg_resources.get_distribution('packse').version)")
+          installed=$(python3 -c "from importlib.metadata import version; print(version('packse'))")
           test $installed = ${{ needs.build-and-publish.outputs.build-version }}
 
       - name: Check CLI help

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .envrc
 build/**/*
 dist/**/*
+node_modules


### PR DESCRIPTION
`pkg_resources` are deprecated in favor of `importlib.metadata`.

Does this allow removing the setuptools dependency or is this used elsewhere?