### PR TITLE
Allow scenarios to set a Python platform

### DIFF
--- a/scenarios/wheels/no-sdist-no-wheels-with-matching-abi.toml
+++ b/scenarios/wheels/no-sdist-no-wheels-with-matching-abi.toml
@@ -10,3 +10,6 @@ satisfiable = false
 [packages.a.versions."1.0.0"]
 wheel_tags = ["py3-MMMMMM-any"]
 sdist = false
+
+[resolver_options]
+python_platform = "x86_64-manylinux2014"

--- a/scenarios/wheels/no-sdist-no-wheels-with-matching-platform.toml
+++ b/scenarios/wheels/no-sdist-no-wheels-with-matching-platform.toml
@@ -10,3 +10,6 @@ satisfiable = false
 [packages.a.versions."1.0.0"]
 wheel_tags = ["py3-none-macosx_10_0_ppc64"]
 sdist = false
+
+[resolver_options]
+python_platform = "x86_64-manylinux2014"

--- a/scenarios/wheels/no-sdist-no-wheels-with-matching-python.toml
+++ b/scenarios/wheels/no-sdist-no-wheels-with-matching-python.toml
@@ -10,3 +10,6 @@ satisfiable = false
 [packages.a.versions."1.0.0"]
 wheel_tags = ["jy27-none-any"]
 sdist = false
+
+[resolver_options]
+python_platform = "x86_64-manylinux2014"

--- a/src/packse/scenario.py
+++ b/src/packse/scenario.py
@@ -139,6 +139,11 @@ class ResolverOptions(msgspec.Struct, forbid_unknown_fields=True):
     non-overlapping marker expressions.
     """
 
+    python_platform: str | None = None
+    """
+    The Python platform to use for resolution.
+    """
+
     def hash(self) -> str:
         """
         Return a hash of the contents
@@ -152,6 +157,10 @@ class ResolverOptions(msgspec.Struct, forbid_unknown_fields=True):
             hasher.update(no_binary.encode())
         for no_build in self.no_build:
             hasher.update(no_build.encode())
+        if self.universal is not None:
+            hasher.update(self.universal.to_bytes())
+        if self.python_platform is not None:
+            hasher.update(self.python_platform.encode())
 
         return hasher.hexdigest()
 

--- a/tests/__snapshots__/test_inspect.ambr
+++ b/tests/__snapshots__/test_inspect.ambr
@@ -114,7 +114,8 @@
               "prereleases": false,
               "no_build": [],
               "no_binary": [],
-              "universal": false
+              "universal": false,
+              "python_platform": null
             },
             "template": "package",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`.",
@@ -251,7 +252,8 @@
               "prereleases": false,
               "no_build": [],
               "no_binary": [],
-              "universal": false
+              "universal": false,
+              "python_platform": null
             },
             "template": "package",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`.",
@@ -415,7 +417,8 @@
               "prereleases": false,
               "no_build": [],
               "no_binary": [],
-              "universal": false
+              "universal": false,
+              "python_platform": null
             },
             "template": "package",
             "description": "This is an example scenario written in TOML, in which the user depends on a single package `a` which requires `b`.",
@@ -552,7 +555,8 @@
               "prereleases": false,
               "no_build": [],
               "no_binary": [],
-              "universal": false
+              "universal": false,
+              "python_platform": null
             },
             "template": "package",
             "description": "This is an example scenario written in YAML, in which the user depends on a single package `a` which requires `b`.",


### PR DESCRIPTION
## Summary

In uv, we're starting to show "compatible tags" in error messages. If we don't set the Python platform, then the displayed tag will vary based on the host machine.
