### PR TITLE
Use valid wheel tags for no-matching tests

### DIFF
--- a/scenarios/wheels/no-sdist-no-wheels-with-matching-abi.toml
+++ b/scenarios/wheels/no-sdist-no-wheels-with-matching-abi.toml
@@ -8,7 +8,7 @@ requires = ["a"]
 satisfiable = false
 
 [packages.a.versions."1.0.0"]
-wheel_tags = ["py3-MMMMMM-any"]
+wheel_tags = ["py3-graalpy310_graalpy240_310_native-any"]
 sdist = false
 
 [resolver_options]

--- a/scenarios/wheels/no-sdist-no-wheels-with-matching-python.toml
+++ b/scenarios/wheels/no-sdist-no-wheels-with-matching-python.toml
@@ -8,7 +8,7 @@ requires = ["a"]
 satisfiable = false
 
 [packages.a.versions."1.0.0"]
-wheel_tags = ["jy27-none-any"]
+wheel_tags = ["graalpy310-none-any"]
 sdist = false
 
 [resolver_options]


### PR DESCRIPTION
## Summary

I'm making our tag-parsing stricter, and these now get filtered out. We should use real (but non-matching) tags.