### PR TITLE
Fix markers in optional dependencies

### DIFF
--- a/src/packse/templates/package/{{ package-name }}-{{ version }}/pyproject.toml
+++ b/src/packse/templates/package/{{ package-name }}-{{ version }}/pyproject.toml
@@ -20,6 +20,6 @@ description = '''{{ description }}'''
 [project.optional-dependencies]
 {{# optional-dependencies }}
 {{ name }} = [{{# dependencies }}
-    "{{ . }}",
+    '''{{ . }}''',
 {{/ dependencies }}]
 {{/ optional-dependencies }}


### PR DESCRIPTION
Prevents

```toml
[packages.psycopg.versions."1.0.0".extras]
binary = ["psycopg-binary; implementation_name != 'pypy'"]
```

from becoming

```toml
[project.optional-dependencies]
binary = [
    "marker-variants-have-different-extras-psycopg-binary; implementation_name != "pypy"",
]
```

Same fix as https://github.com/astral-sh/packse/pull/175