### PR TITLE
Add test cases for virtual package priorities

### DIFF
--- a/scenarios/tag_and_markers/virtual-package-extra-priorities.toml
+++ b/scenarios/tag_and_markers/virtual-package-extra-priorities.toml
@@ -1,0 +1,26 @@
+name = "marker-variants-have-different-extras"
+description = "Check the prioritization for virtual extra and marker packages"
+
+[expected]
+satisfiable = true
+
+[environment]
+python = "3.12"
+
+[root]
+requires = [
+  "psycopg[binary] ; platform_python_implementation != 'PyPy'",
+  "psycopg ; platform_python_implementation == 'PyPy'",
+]
+
+[packages.psycopg.versions."1.0.0"]
+requires = ['tzdata; sys_platform == "win32"']
+
+[packages.psycopg.versions."1.0.0".extras]
+binary = ["psycopg-binary; implementation_name != 'pypy'"]
+
+[packages.psycopg-binary.versions."1.0.0"]
+[packages.tzdata.versions."1.0.0"]
+
+[resolver_options]
+universal = true

--- a/scenarios/tag_and_markers/virtual-package-marker-priorities.toml
+++ b/scenarios/tag_and_markers/virtual-package-marker-priorities.toml
@@ -1,0 +1,23 @@
+name = "virtual-package-extra-priorities"
+description = "Check the prioritization for virtual marker packages"
+
+[root]
+requires_python = ">=3.12"
+requires = ["a==1; python_version >= '3.8'", "b; python_version >= '3.9'"]
+
+[expected]
+satisfiable = true
+
+[packages.a.versions."1.0.0"]
+requires = ["b==1 ; python_version >= '3.10'"]
+[packages.a.versions."2.0.0"]
+requires = ["b==1 ; python_version >= '3.10'"]
+
+[packages.b.versions."1.0.0"]
+[packages.b.versions."2.0.0"]
+
+[resolver_options]
+universal = true
+
+[environment]
+python = "3.12"


### PR DESCRIPTION
These test cases were intended for https://github.com/astral-sh/uv/pull/10935. They still test the virtual package priorities, even though they are not observable in the resolution outcome in the current resolver usage. They can be used to observe virtual package prioritization in resolver verbose mode, so I'd keep them in case we have to follow-up to https://github.com/astral-sh/uv/pull/10935