### PR TITLE
Don't use real platforms for conflict-in-fork

### DIFF
--- a/scenarios/fork/conflict-in-fork.toml
+++ b/scenarios/fork/conflict-in-fork.toml
@@ -10,7 +10,7 @@ universal = true
 satisfiable = false
 
 [root]
-requires = ["a>=2 ; sys_platform == 'linux'", "a<2 ; sys_platform == 'darwin'"]
+requires = ["a>=2 ; sys_platform == 'os1'", "a<2 ; sys_platform == 'os2'"]
 
 [packages.a.versions."1.0.0"]
 requires = ["b", "c"]


### PR DESCRIPTION
This avoids platform specific diagnostics for https://github.com/astral-sh/uv/pull/13455