### PR TITLE
Drop Python 3.9.12 requirement

### DIFF
--- a/scenarios/requires_python/python-greater-than-current-patch.toml
+++ b/scenarios/requires_python/python-greater-than-current-patch.toml
@@ -8,7 +8,7 @@ requires = ["a==1.0.0"]
 satisfiable = false
 
 [packages.a.versions."1.0.0"]
-requires_python = ">=3.9.14"
+requires_python = ">=3.13.2"
 
 [environment]
-python = "3.9.12"
+python = "3.13.0"


### PR DESCRIPTION
Python 3.9.12 is as twice as large as other Pythons on Windows (~40MB vs ~20MB), and there's only one test using it. With this change, we can drop it from the uv `.python-versions`.