### PR TITLE
Switch to monthly renovate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":configMigration",
+    ":semanticCommitsDisabled"
+  ],
+  "schedule": [
+    "before 4am on the first day of the month"
+  ]
+}


### PR DESCRIPTION
Switch to renovate to pin GitHub Actions.

We don't update packse that often, we can reduce the number of PRs a bit with monthly updates over weekly updates.
